### PR TITLE
Fixes and updates to support latest plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.cache/
+/.vscode/
 /build/
 /trash/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This contains a hosting library, providing a JSFX compiler and runtime.
 In addition, there is an audio plugin which can act as a JSFX host in a digital
 audio workstation.
 
+# Forked Project
+
+Note, this is a fork of YSFX with a few modifications to support newer JSFX
+features and fix some existing bugs.
+
 ## Remarks
 
 Despite what the name might suggest, JSFX is not JavaScript.
@@ -21,13 +26,16 @@ These technologies are unrelated to each other.
 
 This project is not the work of Cockos, Inc; however, it is based on several
 free and open source components from the WDL. Originally, this project was based
-on jsusfx by Pascal Gauthier, but then it became an entire rewrite made from
-scratch.
+on jsusfx by Pascal Gauthier, which was then rewritten by jpcima.
 
 Some time after the realization of this project, Cockos announced the release of
 JSFX as open source under the LGPL. This does not affect the development of this
 project, which remains a custom implementation based on the liberally licensed
 bits of the WDL.
+
+Unfortunately, the original maintainer (jpcima) seems to have disappeared, so 
+I (Joep Vanlier) have decided to fork the project to update it with some more 
+recent JSFX features and bugfixes.
 
 # Usage notes
 

--- a/cmake.plugin.txt
+++ b/cmake.plugin.txt
@@ -1,5 +1,6 @@
 # -*- cmake -*-
 # Copyright 2021 Jean Pierre Cimalando
+# Copyright 2024 Joep Vanlier
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Modifications by Joep Vanlier, 2024
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -39,8 +42,8 @@ endif()
 juce_add_plugin(ysfx_plugin
   PLUGIN_CODE "ysfx"
   PLUGIN_MANUFACTURER_CODE "Jpci"
-  PRODUCT_NAME "ysfx"
-  COMPANY_NAME "Jean Pierre Cimalando"
+  PRODUCT_NAME "ysfx_saike_mod"
+  COMPANY_NAME "Jean Pierre Cimalando / Joep Vanlier"
   FORMATS VST3 AU
   NEEDS_MIDI_INPUT TRUE
   NEEDS_MIDI_OUTPUT TRUE

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -1,4 +1,5 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -49,7 +52,7 @@ extern "C" {
 typedef double ysfx_real;
 
 enum {
-    ysfx_max_sliders = 64,
+    ysfx_max_sliders = 256,
     ysfx_max_channels = 64,
     ysfx_max_midi_buses = 16,
     ysfx_max_triggers = 10,

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -1275,7 +1275,7 @@ ysfx_state_t *ysfx_save_state(ysfx_t *fx)
     state->sliders = new ysfx_state_slider_t[slider_count]{};
     state->slider_count = slider_count;
 
-    for (uint32_t i = 0, j = 0; i < slider_count; ++i) {
+    for (uint32_t i = 0, j = 0; i < ysfx_max_sliders; ++i) {
         if (fx->source.main->header.sliders[i].exists) {
             state->sliders[j].index = i;
             state->sliders[j].value = *fx->var.slider[i];

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -109,7 +109,12 @@ ysfx_t *ysfx_new(ysfx_config_t *config)
 
     auto var_resolver = [](void *userdata, const char *name) -> EEL_F * {
         ysfx_t *fx = (ysfx_t *)userdata;
-        auto it = fx->source.slider_alias.find(name);
+
+        /* Not very efficient */
+        std::string lower_name{name};
+        std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), [](unsigned char c){ return std::tolower(c); });
+
+        auto it = fx->source.slider_alias.find(lower_name);
         if (it != fx->source.slider_alias.end())
             return fx->var.slider[it->second];
         return nullptr;
@@ -258,7 +263,11 @@ bool ysfx_load_file(ysfx_t *fx, const char *filepath, uint32_t loadopts)
         for (uint32_t i = 0; i < ysfx_max_sliders; ++i) {
             if (main->header.sliders[i].exists) {
                 if (!main->header.sliders[i].var.empty())
-                    fx->source.slider_alias.insert({main->header.sliders[i].var, i});
+                {
+                    std::string data = main->header.sliders[i].var;
+                    std::transform(data.begin(), data.end(), data.begin(), [](unsigned char c){ return std::tolower(c); });
+                    fx->source.slider_alias.insert({data, i});
+                }
             }
         }
 

--- a/sources/ysfx_api_eel.cpp
+++ b/sources/ysfx_api_eel.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -44,6 +47,7 @@ static ysfx::mutex atomic_mutex;
 #include "WDL/eel2/eel_fft.h"
 #include "WDL/eel2/eel_mdct.h"
 #include "WDL/eel2/eel_atomic.h"
+#include "WDL/eel2/eel_pproc.h"
 
 //------------------------------------------------------------------------------
 void ysfx_api_init_eel()
@@ -141,4 +145,30 @@ void NSEEL_HOSTSTUB_EnterMutex()
 
 void NSEEL_HOSTSTUB_LeaveMutex()
 {
+}
+
+bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str)
+{
+    std::string line;
+    uint32_t lineno = 0;
+
+    line.reserve(256);
+
+    WDL_FastString file_str, pp_str;
+    while (reader.read_next_line(line)) {
+        line += "\n";
+        const char *linep = line.c_str();
+        file_str.Append(linep);
+    }
+
+    EEL2_PreProcessor pproc;
+    const char *err = pproc.preprocess(file_str.Get(), &pp_str);
+    if (err) {
+        error->line = 0;
+        error->message = std::string("Invalid section: ") + err;
+        return false;
+    }
+
+    in_str.append(pp_str.Get(), pp_str.GetLength());
+    return true;
 }

--- a/sources/ysfx_api_eel.hpp
+++ b/sources/ysfx_api_eel.hpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -55,3 +58,5 @@ private:
 #define EEL_STRING_GET_FOR_INDEX(x, wr) (ysfx_string_access_unlocked((ysfx_t *)(opaque), x, wr, false))
 #define EEL_STRING_GET_FOR_WRITE(x, wr) (ysfx_string_access_unlocked((ysfx_t *)(opaque), x, wr, true))
 #define EEL_STRING_MUTEXLOCK_SCOPE ysfx_string_scoped_lock lock{(ysfx_t *)(opaque)};
+
+bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string &str);

--- a/sources/ysfx_api_file.cpp
+++ b/sources/ysfx_api_file.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -387,6 +390,7 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_file_open(void *opaque, EEL_F *file_)
         file.reset(new ysfx_audio_file_t(fx->vm.get(), *(ysfx_audio_format_t *)fmtobj, filepath.c_str()));
         break;
     case ysfx_file_type_none:
+        file.reset(new ysfx_raw_file_t(fx->vm.get(), filepath.c_str()));
         break;
     default:
         assert(false);

--- a/sources/ysfx_api_file.cpp
+++ b/sources/ysfx_api_file.cpp
@@ -307,7 +307,7 @@ int32_t ysfx_serializer_t::avail()
     if (m_write)
         return -1;
     else
-        return 0;
+        return (m_buffer->size() > m_pos) ? 1 : 0;
 }
 
 void ysfx_serializer_t::rewind()

--- a/tests/ysfx_test_preset.cpp
+++ b/tests/ysfx_test_preset.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -129,6 +132,166 @@ TEST_CASE("preset handling", "[preset]")
         REQUIRE(ysfx::unpack_f32le(&state->data[0 * sizeof(float)]) == Approx(0.8));
         REQUIRE(ysfx::unpack_f32le(&state->data[1 * sizeof(float)]) == Approx(0.9));
         REQUIRE(ysfx::unpack_f32le(&state->data[2 * sizeof(float)]) == Approx(1.0));
+    }
+
+    SECTION("Locate preset bank")
+    {
+        const char *text =
+            "desc:example" "\n"
+            "out_pin:output" "\n"
+            "@sample" "\n"
+            "spl0=0.0;" "\n";
+
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
+
+        ysfx_config_u config{ysfx_config_new()};
+        ysfx_u fx{ysfx_new(config.get())};
+
+        {
+            REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+            REQUIRE(ysfx_get_bank_path(fx.get()) == std::string());
+        }
+
+        {
+            scoped_new_txt file_rpl("${root}/Effects/example.jsfx.rpl", "");
+            REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+            REQUIRE(ysfx_get_bank_path(fx.get()) == file_rpl.m_path);
+            ysfx_unload(fx.get());
+            REQUIRE(ysfx_get_bank_path(fx.get()) == std::string());
+        }
+
+        {
+            scoped_new_txt file_rpl("${root}/Effects/example.jsfx.RpL", "");
+            REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+            REQUIRE(!ysfx::ascii_casecmp(ysfx_get_bank_path(fx.get()), file_rpl.m_path.c_str()));
+            ysfx_unload(fx.get());
+            REQUIRE(ysfx_get_bank_path(fx.get()) == std::string());
+        }
+    }
+
+    SECTION("Newer RPL Bank")
+    {
+        const char *source_text =
+            "desc:TestCaseNewRPL" "\n"
+            "slider1:sl1=0<-150,12,1>sl1" "\n"
+            "slider2:sl2=1<-150,12,1>sl2" "\n"
+            "slider2:sl2=2<-150,12,1>sl3" "\n"
+            "slider3:sl3=3<-150,12,1>sl4" "\n"
+            "slider4:sl4=4<-150,12,1>sl5" "\n"
+            "slider5:sl5=5<-150,12,0.5>sl6" "\n"
+            "slider6:sl6=6<-150,12,0.5>sl7" "\n"
+            "slider128:sl7=5<-150,12,1>sl8" "\n"
+            "slider256:sl8=6<-150,12,1:log>sl9" "\n"
+            "@serialize" "\n"
+            "array_loc = 100;" "\n"
+            "array_loc[0] = 5;" "\n"
+            "array_loc[1] = 10;" "\n"
+            "array_loc[2] = 15;" "\n"
+            "array_loc[3] = 20;" "\n"
+            "file_var(0, 1337);" "\n"
+            "file_mem(0, potato, 4);" "\n"
+            "file_var(0, 1338);" "\n";
+
+        const char *rpl_text =
+            "<REAPER_PRESET_LIBRARY \"JS: TestCaseNewRPL\"" "\n"
+            "  <PRESET `Moar`" "\n"
+            "    MCAyIDMgNCAzLjE0MTUgMS4yMzQ1NjggLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSBNb2FyIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIDUgLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSA2AAAgp0QAAKBAAAAgQQAAcEEAAKBBAECnRA==" "\n"
+            "  >" "\n"
+            "  <PRESET `Moar Moar`" "\n" // "Moar Moar"
+            "    MCAyIDMgNCAzLjE0MTUgMS4yMzQ1NjggLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAiTW9hciBNb2FyIiAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSA1IC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gNgAAIKdEAACgQAAAIEEAAHBBAACgQQBAp0Q=" "\n"
+            "  >" "\n"
+            "  <PRESET `Moar \"Moar\" Moar\"`" "\n"  // 'Moar "Moar" Moar"'
+            "    MCAyIDMgNCAzLjE0MTUgMS4yMzQ1NjggLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAnTW9hciAiTW9hciIgTW9hciInIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIDUg" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSA2AAAgp0QAAKBAAAAgQQAAcEEAAKBBAECnRA==" "\n"
+            "  >" "\n"
+            "  <PRESET `Moar \"Moar\" 'Moar\"`" "\n"  // 
+            "    MCAyIDMgNCAzLjE0MTUgMS4yMzQ1NjggLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSBgTW9hciAiTW9hciIgJ01vYXIiYCAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSA1" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAt" "\n"
+            "    IC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gNgAAIKdEAACgQAAAIEEAAHBBAACgQQBAp0Q=" "\n"
+            "  >" "\n"
+            "  <PRESET `Moar \"Moar\"' 'Moar\"`" "\n"
+            "    MCAyIDMgNCAzLjE0MTUgMS4yMzQ1NjggLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAnTW9hciAiTW9hciInICdNb2FyImAgLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    NSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0g" "\n"
+            "    LSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIDYAACCnRAAAoEAAACBBAABwQQAAoEEAQKdE" "\n"
+            "  >" "\n"
+            ">" "\n";
+
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", source_text);
+        scoped_new_txt file_rpl("${root}/Effects/example.jsfx.rpl", rpl_text);
+
+        ysfx_bank_u bank{ysfx_load_bank(file_rpl.m_path.c_str())};
+        REQUIRE(bank);
+
+        REQUIRE(!strcmp(bank->name, "JS: TestCaseNewRPL"));
+
+        REQUIRE(bank->presets != nullptr);
+        REQUIRE(bank->preset_count == 5);
+
+        ysfx_preset_t *preset;
+        ysfx_state_t *state;
+
+        preset = &bank->presets[0];
+        REQUIRE(!strcmp(preset->name, "Moar"));
+        preset = &bank->presets[1];
+        REQUIRE(!strcmp(preset->name, "Moar Moar"));
+        preset = &bank->presets[2];
+        REQUIRE(!strcmp(preset->name, "Moar \"Moar\" Moar\""));
+        preset = &bank->presets[3];
+        REQUIRE(!strcmp(preset->name, "Moar \"Moar\" 'Moar\""));
+        preset = &bank->presets[4];
+        REQUIRE(!strcmp(preset->name, "Moar \"Moar\"' 'Moar\""));
+
+        for (size_t i=0; i<4; i++)
+        {
+            preset = &bank->presets[i];
+            state = preset->state;
+            REQUIRE(state->slider_count == 8);
+            REQUIRE(state->sliders[0].index == 0);
+            REQUIRE(state->sliders[0].value == 0);
+            REQUIRE(state->sliders[1].index == 1);
+            REQUIRE(state->sliders[1].value == 2);
+            REQUIRE(state->sliders[2].index == 2);
+            REQUIRE(state->sliders[2].value == 3);
+            REQUIRE(state->sliders[3].index == 3);
+            REQUIRE(state->sliders[3].value == 4);
+            REQUIRE(state->sliders[4].index == 4);
+            REQUIRE(state->sliders[4].value == 3.1415);
+            REQUIRE(state->sliders[5].index == 5);
+            REQUIRE(state->sliders[5].value == 1.234568);
+            REQUIRE(state->sliders[6].index == 127);
+            REQUIRE(state->sliders[6].value == 5);
+            REQUIRE(state->sliders[7].index == 255);
+            REQUIRE(state->sliders[7].value == 6);
+            REQUIRE(state->data_size == 6 * sizeof(float));
+            REQUIRE(ysfx::unpack_f32le(&state->data[0 * sizeof(float)]) == 1337.0);
+            REQUIRE(ysfx::unpack_f32le(&state->data[1 * sizeof(float)]) == 5.0);
+            REQUIRE(ysfx::unpack_f32le(&state->data[2 * sizeof(float)]) == 10.0);
+            REQUIRE(ysfx::unpack_f32le(&state->data[3 * sizeof(float)]) == 15.0);
+            REQUIRE(ysfx::unpack_f32le(&state->data[4 * sizeof(float)]) == 20.0);
+            REQUIRE(ysfx::unpack_f32le(&state->data[5 * sizeof(float)]) == 1338.0);
+        }
     }
 
     SECTION("Locate preset bank")

--- a/tests/ysfx_test_serialization.cpp
+++ b/tests/ysfx_test_serialization.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,6 +32,8 @@ TEST_CASE("save and load", "[serialization]")
             "out_pin:output" "\n"
             "slider1:1<1,3,0.1>the slider 1" "\n"
             "slider2:2<1,3,0.1>the slider 2" "\n"
+            "slider4:2<1,3,0.1>the slider 4" "\n"
+            "slider256:3<1,3,0.1>the slider 256" "\n"
             "@sample" "\n"
             "spl0=0.0;" "\n";
 
@@ -44,11 +49,15 @@ TEST_CASE("save and load", "[serialization]")
         ysfx_state_u state{ysfx_save_state(fx.get())};
         REQUIRE(state);
         REQUIRE(state->data_size == 0);
-        REQUIRE(state->slider_count == 2);
+        REQUIRE(state->slider_count == 4);
         REQUIRE(state->sliders[0].index == 0);
         REQUIRE(state->sliders[1].index == 1);
         REQUIRE(state->sliders[0].value == 1);
         REQUIRE(state->sliders[1].value == 2);
+        REQUIRE(state->sliders[2].index == 3);
+        REQUIRE(state->sliders[2].value == 2);
+        REQUIRE(state->sliders[3].index == 255);
+        REQUIRE(state->sliders[3].value == 3);
 
         state->sliders[0].value = 2;
         state->sliders[1].value = 3;

--- a/tests/ysfx_test_slider.cpp
+++ b/tests/ysfx_test_slider.cpp
@@ -1,4 +1,6 @@
 // Copyright 2021 Jean Pierre Cimalando
+// Copyright 2024 Joep Vanlier
+//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modifications by Joep Vanlier, 2024
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,6 +35,35 @@ TEST_CASE("slider manipulation", "[sliders]")
             "@init" "\n"
             "foo=2;" "\n"
             "bar=3;" "\n"
+            "@sample" "\n"
+            "spl0=0.0;" "\n";
+
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
+
+        ysfx_config_u config{ysfx_config_new()};
+        ysfx_u fx{ysfx_new(config.get())};
+
+        REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+        REQUIRE(ysfx_compile(fx.get(), 0));
+
+        REQUIRE(ysfx_slider_get_value(fx.get(), 0) == 1);
+        REQUIRE(ysfx_slider_get_value(fx.get(), 1) == 2);
+        ysfx_init(fx.get());
+        REQUIRE(ysfx_slider_get_value(fx.get(), 0) == 2);
+        REQUIRE(ysfx_slider_get_value(fx.get(), 1) == 3);
+    }
+
+    SECTION("slider case insensitivity")
+    {
+        const char *text =
+            "desc:example" "\n"
+            "out_pin:output" "\n"
+            "slider1:fOo=1<1,3,0.1>the slider 1" "\n"
+            "slider2:bar=2<1,3,0.1>the slider 2" "\n"
+            "@init" "\n"
+            "foo=2;" "\n"
+            "bAr=3;" "\n"
             "@sample" "\n"
             "spl0=0.0;" "\n";
 

--- a/thirdparty/WDL/source/WDL/assocarray.h
+++ b/thirdparty/WDL/source/WDL/assocarray.h
@@ -10,7 +10,7 @@
 
 
 // WDL_AssocArrayImpl can be used on its own, and can contain structs for keys or values
-template <class KEY, class VAL> class WDL_AssocArrayImpl 
+template <class KEY, class VAL> class WDL_AssocArrayImpl
 {
   WDL_AssocArrayImpl(const WDL_AssocArrayImpl &cp) { CopyContents(cp); }
 
@@ -18,7 +18,10 @@ template <class KEY, class VAL> class WDL_AssocArrayImpl
 
 public:
 
-  explicit WDL_AssocArrayImpl(int (*keycmp)(KEY *k1, KEY *k2), KEY (*keydup)(KEY)=0, void (*keydispose)(KEY)=0, void (*valdispose)(VAL)=0)
+  explicit WDL_AssocArrayImpl(int (*keycmp)(KEY *k1, KEY *k2),
+                              KEY (*keydup)(KEY)=NULL,
+                              void (*keydispose)(KEY)=NULL,
+                              void (*valdispose)(VAL)=NULL)
   {
     m_keycmp = keycmp;
     m_keydup = keydup;
@@ -26,7 +29,7 @@ public:
     m_valdispose = valdispose;
   }
 
-  ~WDL_AssocArrayImpl() 
+  ~WDL_AssocArrayImpl()
   {
     DeleteAll();
   }
@@ -63,11 +66,14 @@ public:
     }
     else
     {
-      KeyVal* kv = m_data.Resize(m_data.GetSize()+1)+i;
-      memmove(kv+1, kv, (m_data.GetSize()-i-1)*(unsigned int)sizeof(KeyVal));
-      if (m_keydup) key = m_keydup(key);
-      kv->key = key;
-      kv->val = val;      
+      KeyVal *kv = m_data.ResizeOK(m_data.GetSize()+1);
+      if (WDL_NORMALLY(kv != NULL))
+      {
+        memmove(kv+i+1, kv+i, (m_data.GetSize()-i-1)*sizeof(KeyVal));
+        if (m_keydup) key = m_keydup(key);
+        kv[i].key = key;
+        kv[i].val = val;
+      }
     }
     return i;
   }
@@ -116,7 +122,7 @@ public:
     return m_data.GetSize();
   }
 
-  VAL* EnumeratePtr(int i, KEY* key=0) const
+  VAL* EnumeratePtr(int i, KEY* key=NULL) const
   {
     if (i >= 0 && i < m_data.GetSize()) 
     {
@@ -169,10 +175,13 @@ public:
   void AddUnsorted(KEY key, VAL val)
   {
     int i=m_data.GetSize();
-    KeyVal* kv = m_data.Resize(i+1)+i;
-    if (m_keydup) key = m_keydup(key);
-    kv->key = key;
-    kv->val = val;
+    KeyVal *kv = m_data.ResizeOK(i+1);
+    if (WDL_NORMALLY(kv != NULL))
+    {
+      if (m_keydup) key = m_keydup(key);
+      kv[i].key = key;
+      kv[i].val = val;
+    }
   }
 
   void Resort(int (*new_keycmp)(KEY *k1, KEY *k2)=NULL)
@@ -251,12 +260,11 @@ public:
     m_valdispose = NULL; // avoid disposing of values twice, since we don't have a valdup, we can't have a fully valid copy
     if (m_keydup)
     {
-      int x;
       const int n=m_data.GetSize();
-      for (x=0;x<n;x++)
+      for (int x=0;x<n;x++)
       {
         KeyVal *kv=m_data.Get()+x;
-        if (kv->key) kv->key = m_keydup(kv->key);
+        kv->key = m_keydup(kv->key);
       }
     }
   }
@@ -280,6 +288,8 @@ public:
     VAL val;
   };
   WDL_TypedBuf<KeyVal> m_data;
+
+  static int keycmp_ptr(KEY *a, KEY *b) { return (INT_PTR)*a > (INT_PTR)*b ? 1 : (INT_PTR)*a < (INT_PTR)*b ? -1 : 0; }
 
 protected:
 
@@ -321,8 +331,10 @@ template <class KEY, class VAL> class WDL_AssocArray : public WDL_AssocArrayImpl
 {
 public:
 
-  explicit WDL_AssocArray(int (*keycmp)(KEY *k1, KEY *k2), KEY (*keydup)(KEY)=0, void (*keydispose)(KEY)=0, void (*valdispose)(VAL)=0)
-  : WDL_AssocArrayImpl<KEY, VAL>(keycmp, keydup, keydispose, valdispose)
+  explicit WDL_AssocArray(int (*keycmp)(KEY *k1, KEY *k2),
+                          KEY (*keydup)(KEY)=NULL,
+                          void (*keydispose)(KEY)=NULL, void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArrayImpl<KEY, VAL>(keycmp, keydup, keydispose, valdispose)
   { 
   }
 
@@ -333,7 +345,7 @@ public:
     return notfound;
   }
 
-  VAL Enumerate(int i, KEY* key=0, VAL notfound=0) const
+  VAL Enumerate(int i, KEY* key=NULL, VAL notfound=0) const
   {
     VAL* p = this->EnumeratePtr(i, key);
     if (p) return *p;
@@ -353,33 +365,28 @@ template <class VAL> class WDL_IntKeyedArray : public WDL_AssocArray<int, VAL>
 {
 public:
 
-  explicit WDL_IntKeyedArray(void (*valdispose)(VAL)=0) : WDL_AssocArray<int, VAL>(cmpint, NULL, NULL, valdispose) {}
-  ~WDL_IntKeyedArray() {}
+  explicit WDL_IntKeyedArray(void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArray<int, VAL>(cmpint, NULL, NULL, valdispose) {}
 
-private:
-
-  static int cmpint(int *i1, int *i2) { return *i1-*i2; }
+  static int cmpint(int *a, int *b) { return *a > *b ? 1 : *a < *b ? -1 : 0; }
 };
 
 template <class VAL> class WDL_IntKeyedArray2 : public WDL_AssocArrayImpl<int, VAL>
 {
 public:
 
-  explicit WDL_IntKeyedArray2(void (*valdispose)(VAL)=0) : WDL_AssocArrayImpl<int, VAL>(cmpint, NULL, NULL, valdispose) {}
-  ~WDL_IntKeyedArray2() {}
+  explicit WDL_IntKeyedArray2(void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArrayImpl<int, VAL>(cmpint, NULL, NULL, valdispose) {}
 
-private:
-
-  static int cmpint(int *i1, int *i2) { return *i1-*i2; }
+  static int cmpint(int *a, int *b) { return *a > *b ? 1 : *a < *b ? -1 : 0; }
 };
 
 template <class VAL> class WDL_StringKeyedArray : public WDL_AssocArray<const char *, VAL>
 {
 public:
 
-  explicit WDL_StringKeyedArray(bool caseSensitive=true, void (*valdispose)(VAL)=0) : WDL_AssocArray<const char*, VAL>(caseSensitive?cmpstr:cmpistr, dupstr, freestr, valdispose) {}
-  
-  ~WDL_StringKeyedArray() { }
+  explicit WDL_StringKeyedArray(bool caseSensitive=true, void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArray<const char*, VAL>(caseSensitive?cmpstr:cmpistr, dupstr, freestr, valdispose) {}
 
   static const char *dupstr(const char *s) { return strdup(s);  } // these might not be necessary but depending on the libc maybe...
   static int cmpstr(const char **s1, const char **s2) { return strcmp(*s1, *s2); }
@@ -393,7 +400,8 @@ template <class VAL> class WDL_StringKeyedArray2 : public WDL_AssocArrayImpl<con
 {
 public:
 
-  explicit WDL_StringKeyedArray2(bool caseSensitive=true, void (*valdispose)(VAL)=0) : WDL_AssocArrayImpl<const char*, VAL>(caseSensitive?cmpstr:cmpistr, dupstr, freestr, valdispose) {}
+  explicit WDL_StringKeyedArray2(bool caseSensitive=true, void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArrayImpl<const char*, VAL>(caseSensitive?cmpstr:cmpistr, dupstr, freestr, valdispose) {}
   
   ~WDL_StringKeyedArray2() { }
 
@@ -409,31 +417,80 @@ template <class VAL> class WDL_LogicalSortStringKeyedArray : public WDL_StringKe
 {
 public:
 
-  explicit WDL_LogicalSortStringKeyedArray(bool caseSensitive=true, void (*valdispose)(VAL)=0) : WDL_StringKeyedArray<VAL>(caseSensitive, valdispose) 
+  explicit WDL_LogicalSortStringKeyedArray(bool caseSensitive=true, void (*valdispose)(VAL)=NULL)
+    : WDL_StringKeyedArray<VAL>(caseSensitive, valdispose)
   {
     WDL_StringKeyedArray<VAL>::m_keycmp = caseSensitive?cmpstr:cmpistr; // override
   }
   
   ~WDL_LogicalSortStringKeyedArray() { }
 
-  static int cmpstr(const char **a, const char **b) { return WDL_strcmp_logical(*a, *b, 1); }
-  static int cmpistr(const char **a, const char **b) { return WDL_strcmp_logical(*a, *b, 0); }
-
+  static int cmpstr(const char **a, const char **b)
+  {
+    int r=WDL_strcmp_logical_ex(*a, *b, 1, WDL_STRCMP_LOGICAL_EX_FLAG_UTF8CONVERT);
+    return r?r:strcmp(*a,*b);
+  }
+  static int cmpistr(const char **a, const char **b)
+  {
+    int r=WDL_strcmp_logical_ex(*a, *b, 0, WDL_STRCMP_LOGICAL_EX_FLAG_UTF8CONVERT);
+    return r?r:stricmp(*a,*b);
+  }
 };
 
 
 template <class VAL> class WDL_PtrKeyedArray : public WDL_AssocArray<INT_PTR, VAL>
 {
 public:
-
-  explicit WDL_PtrKeyedArray(void (*valdispose)(VAL)=0) : WDL_AssocArray<INT_PTR, VAL>(cmpptr, 0, 0, valdispose) {}
-
-  ~WDL_PtrKeyedArray() {}
-
-private:
-  
-  static int cmpptr(INT_PTR* a, INT_PTR* b) { const INT_PTR d = *a - *b; return d<0?-1:(d!=0); }
+  explicit WDL_PtrKeyedArray(void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArray<INT_PTR, VAL>(WDL_AssocArray<INT_PTR, VAL>::keycmp_ptr, NULL, NULL, valdispose) {}
 };
+
+template <class KEY, class VAL> class WDL_PointerKeyedArray : public WDL_AssocArray<KEY, VAL>
+{
+public:
+  explicit WDL_PointerKeyedArray(void (*valdispose)(VAL)=NULL)
+    : WDL_AssocArray<KEY, VAL>(WDL_AssocArray<KEY, VAL>::keycmp_ptr, NULL, NULL, valdispose) {}
+};
+
+struct WDL_Set_DummyRec { };
+template <class KEY> class WDL_Set : public WDL_AssocArrayImpl<KEY,WDL_Set_DummyRec>
+{
+  public:
+  explicit WDL_Set(int (*keycmp)(KEY *k1, KEY *k2),
+                            KEY (*keydup)(KEY)=NULL,
+                            void (*keydispose)(KEY)=NULL
+      )
+    : WDL_AssocArrayImpl<KEY, WDL_Set_DummyRec>(keycmp,keydup,keydispose)
+  {
+  }
+
+  int Insert(KEY key)
+  {
+    WDL_Set_DummyRec r;
+    return WDL_AssocArrayImpl<KEY, WDL_Set_DummyRec>::Insert(key,r);
+  }
+  void AddUnsorted(KEY key)
+  {
+    WDL_Set_DummyRec r;
+    WDL_AssocArrayImpl<KEY, WDL_Set_DummyRec>::AddUnsorted(key,r);
+  }
+
+  bool Get(KEY key) const
+  {
+    return WDL_AssocArrayImpl<KEY, WDL_Set_DummyRec>::Exists(key);
+  }
+  bool Enumerate(int i, KEY *key=NULL)
+  {
+    return WDL_AssocArrayImpl<KEY, WDL_Set_DummyRec>::EnumeratePtr(i,key) != NULL;
+  }
+};
+
+template <class KEY> class WDL_PtrSet : public WDL_Set<KEY>
+{
+public:
+  explicit WDL_PtrSet() : WDL_Set<KEY>( WDL_AssocArray<KEY, WDL_Set_DummyRec>::keycmp_ptr ) { }
+};
+
 
 
 #endif

--- a/thirdparty/WDL/source/WDL/eel2/asm-nseel-aarch64-gcc.c
+++ b/thirdparty/WDL/source/WDL/eel2/asm-nseel-aarch64-gcc.c
@@ -332,11 +332,11 @@ void nseel_asm_mod(void)
     FUNCTION_MARKER
     "fabs d0, d0\n"
     "fabs d1, d1\n"
-    "fcvtzu w1, d0\n"
-    "fcvtzu w0, d1\n"
-    "udiv w2, w0, w1\n"
-    "msub w0, w2, w1, w0\n"
-    "ucvtf d0, w0\n"
+    "fcvtzu x1, d0\n"
+    "fcvtzu x0, d1\n"
+    "udiv x2, x0, x1\n"
+    "msub x0, x2, x1, x0\n"
+    "ucvtf d0, x0\n"
     FUNCTION_MARKER
   );
 }
@@ -373,11 +373,11 @@ void nseel_asm_mod_op(void)
     "ldr d1, [x1]\n"
     "fabs d0, d0\n"
     "fabs d1, d1\n"
-    "fcvtzu w3, d0\n"
-    "fcvtzu w0, d1\n"
-    "udiv w2, w0, w3\n"
-    "msub w0, w2, w3, w0\n"
-    "ucvtf d0, w0\n"
+    "fcvtzu x3, d0\n"
+    "fcvtzu x0, d1\n"
+    "udiv x2, x0, x3\n"
+    "msub x0, x2, x3, x0\n"
+    "ucvtf d0, x0\n"
 
     "str d0, [x1]\n"
     "mov x0, x1\n"

--- a/thirdparty/WDL/source/WDL/eel2/asm-nseel-arm-gcc.c
+++ b/thirdparty/WDL/source/WDL/eel2/asm-nseel-arm-gcc.c
@@ -4,8 +4,7 @@
 
 #if EEL_F_SIZE == 8
 
-__attribute__((naked, target("arm")))
-void nseel_asm_1pdd(void)
+__attribute__((naked)) void nseel_asm_1pdd(void)
 {
 
   __asm__ __volatile__( 
@@ -19,8 +18,7 @@ void nseel_asm_1pdd(void)
    :: );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_2pdd(void)
+__attribute__((naked)) void nseel_asm_2pdd(void)
 {
 
   __asm__ __volatile__( 
@@ -37,8 +35,7 @@ void nseel_asm_2pdd(void)
    :: );
 };
 
-__attribute__((naked, target("arm")))
-void nseel_asm_2pdds(void)
+__attribute__((naked)) void nseel_asm_2pdds(void)
 {
   __asm__ __volatile__( 
     FUNCTION_MARKER
@@ -63,8 +60,7 @@ void nseel_asm_2pdds(void)
 //---------------------------------------------------------------------------------------------------------------
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_invsqrt(void)
+__attribute__((naked)) void nseel_asm_invsqrt(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -90,8 +86,7 @@ void nseel_asm_invsqrt(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_dbg_getstackptr(void)
+__attribute__((naked)) void nseel_asm_dbg_getstackptr(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -103,8 +98,7 @@ void nseel_asm_dbg_getstackptr(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_sqr(void)
+__attribute__((naked)) void nseel_asm_sqr(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -115,8 +109,7 @@ void nseel_asm_sqr(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_abs(void)
+__attribute__((naked)) void nseel_asm_abs(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -139,8 +132,7 @@ void nseel_asm_abs(void)
    "0:\n"
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_assign(void)
+__attribute__((naked)) void nseel_asm_assign(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -154,8 +146,7 @@ void nseel_asm_assign(void)
 }
 //
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_assign_fromfp(void)
+__attribute__((naked)) void nseel_asm_assign_fromfp(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -167,8 +158,7 @@ void nseel_asm_assign_fromfp(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_assign_fast(void)
+__attribute__((naked)) void nseel_asm_assign_fast(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -180,8 +170,7 @@ void nseel_asm_assign_fast(void)
 }
 //
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_assign_fast_fromfp(void)
+__attribute__((naked)) void nseel_asm_assign_fast_fromfp(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -194,8 +183,7 @@ void nseel_asm_assign_fast_fromfp(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_add(void)
+__attribute__((naked)) void nseel_asm_add(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -204,8 +192,7 @@ void nseel_asm_add(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_add_op(void)
+__attribute__((naked)) void nseel_asm_add_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -218,8 +205,7 @@ void nseel_asm_add_op(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_add_op_fast(void)
+__attribute__((naked)) void nseel_asm_add_op_fast(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -233,8 +219,7 @@ void nseel_asm_add_op_fast(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_sub(void)
+__attribute__((naked)) void nseel_asm_sub(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -243,8 +228,7 @@ void nseel_asm_sub(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_sub_op(void)
+__attribute__((naked)) void nseel_asm_sub_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -257,8 +241,7 @@ void nseel_asm_sub_op(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_sub_op_fast(void)
+__attribute__((naked)) void nseel_asm_sub_op_fast(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -271,8 +254,7 @@ void nseel_asm_sub_op_fast(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_mul(void)
+__attribute__((naked)) void nseel_asm_mul(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -281,8 +263,7 @@ void nseel_asm_mul(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_mul_op(void)
+__attribute__((naked)) void nseel_asm_mul_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -295,8 +276,7 @@ void nseel_asm_mul_op(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_mul_op_fast(void)
+__attribute__((naked)) void nseel_asm_mul_op_fast(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -309,8 +289,7 @@ void nseel_asm_mul_op_fast(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_div(void)
+__attribute__((naked)) void nseel_asm_div(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -319,8 +298,7 @@ void nseel_asm_div(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_div_op(void)
+__attribute__((naked)) void nseel_asm_div_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -333,8 +311,7 @@ void nseel_asm_div_op(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_div_op_fast(void)
+__attribute__((naked)) void nseel_asm_div_op_fast(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -347,8 +324,7 @@ void nseel_asm_div_op_fast(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_mod(void)
+__attribute__((naked)) void nseel_asm_mod(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -371,8 +347,7 @@ void nseel_asm_mod(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_shl(void)
+__attribute__((naked)) void nseel_asm_shl(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -387,8 +362,7 @@ void nseel_asm_shl(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_shr(void)
+__attribute__((naked)) void nseel_asm_shr(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -403,8 +377,7 @@ void nseel_asm_shr(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_mod_op(void)
+__attribute__((naked)) void nseel_asm_mod_op(void)
 {
 
   __asm__ __volatile__(
@@ -434,8 +407,7 @@ void nseel_asm_mod_op(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_or(void)
+__attribute__((naked)) void nseel_asm_or(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -450,8 +422,7 @@ void nseel_asm_or(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_or0(void)
+__attribute__((naked)) void nseel_asm_or0(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -461,8 +432,7 @@ void nseel_asm_or0(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_or_op(void)
+__attribute__((naked)) void nseel_asm_or_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -481,8 +451,7 @@ void nseel_asm_or_op(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_xor(void)
+__attribute__((naked)) void nseel_asm_xor(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -497,8 +466,7 @@ void nseel_asm_xor(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_xor_op(void)
+__attribute__((naked)) void nseel_asm_xor_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -517,8 +485,7 @@ void nseel_asm_xor_op(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_and(void)
+__attribute__((naked)) void nseel_asm_and(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -532,8 +499,7 @@ void nseel_asm_and(void)
     FUNCTION_MARKER
   );}
 
-__attribute__((naked, target("arm")))
-void nseel_asm_and_op(void)
+__attribute__((naked)) void nseel_asm_and_op(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -553,8 +519,7 @@ void nseel_asm_and_op(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_uminus(void)
+__attribute__((naked)) void nseel_asm_uminus(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -565,8 +530,7 @@ void nseel_asm_uminus(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_sign(void)
+__attribute__((naked)) void nseel_asm_sign(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -582,8 +546,7 @@ void nseel_asm_sign(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_bnot(void)
+__attribute__((naked)) void nseel_asm_bnot(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -595,8 +558,7 @@ void nseel_asm_bnot(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_if(void)
+__attribute__((naked)) void nseel_asm_if(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -614,8 +576,7 @@ void nseel_asm_if(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_repeat(void)
+__attribute__((naked)) void nseel_asm_repeat(void)
 {
 #if NSEEL_LOOPFUNC_SUPPORT_MAXLEN > 0
   __asm__ __volatile__(
@@ -672,8 +633,7 @@ void nseel_asm_repeat(void)
 #endif
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_repeatwhile(void)
+__attribute__((naked)) void nseel_asm_repeatwhile(void)
 {
 #if NSEEL_LOOPFUNC_SUPPORT_MAXLEN > 0
   __asm__ __volatile__(
@@ -720,8 +680,7 @@ void nseel_asm_repeatwhile(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_band(void)
+__attribute__((naked)) void nseel_asm_band(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -737,8 +696,7 @@ void nseel_asm_band(void)
   :: );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_bor(void)
+__attribute__((naked)) void nseel_asm_bor(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -755,8 +713,7 @@ void nseel_asm_bor(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_equal(void)
+__attribute__((naked)) void nseel_asm_equal(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -772,8 +729,7 @@ void nseel_asm_equal(void)
   );
 }
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_equal_exact(void)
+__attribute__((naked)) void nseel_asm_equal_exact(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -787,8 +743,7 @@ void nseel_asm_equal_exact(void)
 }
 //
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_notequal_exact(void)
+__attribute__((naked)) void nseel_asm_notequal_exact(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -804,8 +759,7 @@ void nseel_asm_notequal_exact(void)
 //
 //
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_notequal(void)
+__attribute__((naked)) void nseel_asm_notequal(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -823,8 +777,7 @@ void nseel_asm_notequal(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_below(void)
+__attribute__((naked)) void nseel_asm_below(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -838,8 +791,7 @@ void nseel_asm_below(void)
 }
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_beloweq(void)
+__attribute__((naked)) void nseel_asm_beloweq(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -854,8 +806,7 @@ void nseel_asm_beloweq(void)
 
 
 //---------------------------------------------------------------------------------------------------------------
-__attribute__((naked, target("arm")))
-void nseel_asm_above(void)
+__attribute__((naked)) void nseel_asm_above(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -868,8 +819,7 @@ void nseel_asm_above(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_aboveeq(void)
+__attribute__((naked)) void nseel_asm_aboveeq(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -884,8 +834,7 @@ void nseel_asm_aboveeq(void)
 
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_min(void)
+__attribute__((naked)) void nseel_asm_min(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -898,8 +847,7 @@ void nseel_asm_min(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_max(void)
+__attribute__((naked)) void nseel_asm_max(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -914,8 +862,7 @@ void nseel_asm_max(void)
 
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_min_fp(void)
+__attribute__((naked)) void nseel_asm_min_fp(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -926,8 +873,7 @@ void nseel_asm_min_fp(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_max_fp(void)
+__attribute__((naked)) void nseel_asm_max_fp(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -944,8 +890,7 @@ void nseel_asm_max_fp(void)
 
 
 
-__attribute__((naked, target("arm")))
-void _asm_generic3parm(void)
+__attribute__((naked)) void _asm_generic3parm(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -970,8 +915,7 @@ void _asm_generic3parm(void)
  ); 
 }
 
-__attribute__((naked, target("arm")))
-void _asm_generic3parm_retd(void)
+__attribute__((naked)) void _asm_generic3parm_retd(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -997,8 +941,7 @@ void _asm_generic3parm_retd(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void _asm_generic2parm(void)
+__attribute__((naked)) void _asm_generic2parm(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1016,8 +959,7 @@ void _asm_generic2parm(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void _asm_generic2parm_retd(void)
+__attribute__((naked)) void _asm_generic2parm_retd(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1035,8 +977,7 @@ void _asm_generic2parm_retd(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void _asm_generic2xparm_retd(void)
+__attribute__((naked)) void _asm_generic2xparm_retd(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1056,8 +997,7 @@ void _asm_generic2xparm_retd(void)
  );
 }
 
-__attribute__((naked, target("arm")))
-void _asm_generic1parm(void)
+__attribute__((naked)) void _asm_generic1parm(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1076,8 +1016,7 @@ void _asm_generic1parm(void)
 
 
 
-__attribute__((naked, target("arm")))
-void _asm_generic1parm_retd(void)
+__attribute__((naked)) void _asm_generic1parm_retd(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1097,8 +1036,7 @@ void _asm_generic1parm_retd(void)
 
 
 
-__attribute__((naked, target("arm")))
-void _asm_megabuf(void)
+__attribute__((naked)) void _asm_megabuf(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1142,8 +1080,7 @@ void _asm_megabuf(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void _asm_gmegabuf(void)
+__attribute__((naked)) void _asm_gmegabuf(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1170,8 +1107,7 @@ void _asm_gmegabuf(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_fcall(void)
+__attribute__((naked)) void nseel_asm_fcall(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1186,8 +1122,7 @@ void nseel_asm_fcall(void)
 
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_push(void)
+__attribute__((naked)) void nseel_asm_stack_push(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1213,8 +1148,7 @@ void nseel_asm_stack_push(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_pop(void)
+__attribute__((naked)) void nseel_asm_stack_pop(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1238,8 +1172,7 @@ void nseel_asm_stack_pop(void)
 
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_pop_fast(void)
+__attribute__((naked)) void nseel_asm_stack_pop_fast(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1259,8 +1192,7 @@ void nseel_asm_stack_pop_fast(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_peek(void)
+__attribute__((naked)) void nseel_asm_stack_peek(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1283,8 +1215,7 @@ void nseel_asm_stack_peek(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_peek_top(void)
+__attribute__((naked)) void nseel_asm_stack_peek_top(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1296,8 +1227,7 @@ void nseel_asm_stack_peek_top(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_peek_int(void)
+__attribute__((naked)) void nseel_asm_stack_peek_int(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1319,8 +1249,7 @@ void nseel_asm_stack_peek_int(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_stack_exch(void)
+__attribute__((naked)) void nseel_asm_stack_exch(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1336,8 +1265,7 @@ void nseel_asm_stack_exch(void)
 }
 
 
-__attribute__((naked, target("arm")))
-void nseel_asm_booltofp(void)
+__attribute__((naked)) void nseel_asm_booltofp(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1348,8 +1276,7 @@ void nseel_asm_booltofp(void)
   );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_fptobool(void)
+__attribute__((naked)) void nseel_asm_fptobool(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER
@@ -1364,8 +1291,7 @@ void nseel_asm_fptobool(void)
           );
 }
 
-__attribute__((naked, target("arm")))
-void nseel_asm_fptobool_rev(void)
+__attribute__((naked)) void nseel_asm_fptobool_rev(void)
 {
   __asm__ __volatile__(
     FUNCTION_MARKER

--- a/thirdparty/WDL/source/WDL/eel2/eel_lice.h
+++ b/thirdparty/WDL/source/WDL/eel2/eel_lice.h
@@ -205,7 +205,73 @@ public:
 
   LICE_IBitmap *m_framebuffer, *m_framebuffer_extra;
   int m_framebuffer_dirty;
-  WDL_TypedBuf<LICE_IBitmap *> m_gfx_images;
+
+  struct img_shared_state
+  {
+    LICE_IBitmap *bm;
+    int refcnt;
+
+    img_shared_state(LICE_IBitmap *b) : bm(b), refcnt(1) { }
+
+    void release()
+    {
+      if (wdl_atomic_decr(&refcnt)==0) delete this;
+    }
+
+    private:
+
+    ~img_shared_state()
+    {
+      s_img_cache_mutex.Enter();
+      for (int x = 0; x < s_img_cache.GetSize(); x ++)
+      {
+        if (s_img_cache.Enumerate(x) == this)
+        {
+          s_img_cache.DeleteByIndex(x);
+          break;
+        }
+      }
+      s_img_cache_mutex.Leave();
+      if (LICE_FUNCTION_VALID(LICE__Destroy)) 
+        LICE__Destroy(bm);
+    }
+  };
+
+  static WDL_StringKeyedArray<img_shared_state *> s_img_cache;
+  static WDL_Mutex s_img_cache_mutex;
+
+  struct img_state
+  {
+    LICE_IBitmap *bm;
+    img_shared_state *shared;
+
+    void clear(LICE_IBitmap *bmnew=NULL, img_shared_state *sharednew=NULL)
+    {
+      if (shared) shared->release();
+      if (bm && LICE_FUNCTION_VALID(LICE__Destroy)) 
+        LICE__Destroy(bm);
+      bm = bmnew;
+      shared = sharednew;
+    }
+    void on_write()
+    {
+      if (shared && WDL_NORMALLY(shared->bm))
+      {
+        const int bmw = LICE__GetWidth(shared->bm), bmh = LICE__GetHeight(shared->bm);
+        bm = __LICE_CreateBitmap(1,bmw,bmh);
+        LICE_ScaledBlit(bm,shared->bm, // copy the entire image
+          0,0,bmw,bmh,
+          0.0f,0.0f,(float)bmw,(float)bmh,
+          1.0f,LICE_BLIT_MODE_COPY);
+        shared->release();
+        shared = NULL;
+      }
+    }
+  };
+
+  bool do_load_image(int img, const char *str);
+
+  WDL_TypedBuf<img_state> m_gfx_images;
   struct gfxFontStruct {
     LICE_IFont *font;
     char last_fontname[128];
@@ -226,14 +292,19 @@ public:
   int m_gfx_font_active; // -1 for default, otherwise index into gfx_fonts (NOTE: this differs from the exposed API, which defines 0 as default, 1-n)
   LICE_IFont *GetActiveFont() { return m_gfx_font_active>=0&&m_gfx_font_active<m_gfx_fonts.GetSize() && m_gfx_fonts.Get()[m_gfx_font_active].use_fonth ? m_gfx_fonts.Get()[m_gfx_font_active].font : NULL; }
 
-  LICE_IBitmap *GetImageForIndex(EEL_F idx, const char *callername) 
+  LICE_IBitmap *GetImageForIndex(EEL_F idx, const char *callername, bool is_wr=true) 
   { 
     if (idx>-2.0)
     {
       if (idx < 0.0) return m_framebuffer;
 
       const int a = (int)idx;
-      if (a >= 0 && a < m_gfx_images.GetSize()) return m_gfx_images.Get()[a];
+      if (a >= 0 && a < m_gfx_images.GetSize())
+      {
+        img_state *rec = m_gfx_images.Get() + a;
+        if (is_wr) rec->on_write();
+        return rec->shared ? rec->shared->bm : rec->bm;
+      }
     }
     return NULL;
   };
@@ -315,6 +386,10 @@ public:
 #endif
 
 #endif
+
+  DWORD m_last_menu_time;
+  int m_last_menu_cnt;
+
   int m_has_cap; // high 16 bits are current capture state, low 16 bits are temporary flags from mousedown
   bool m_has_had_getch; // set on first gfx_getchar(), makes mouse_cap updated with modifiers even when no mouse click is down
 
@@ -323,6 +398,9 @@ public:
 
 
 #ifndef EEL_LICE_API_ONLY
+
+WDL_StringKeyedArray<eel_lice_state::img_shared_state *> eel_lice_state::s_img_cache(true);
+WDL_Mutex eel_lice_state::s_img_cache_mutex;
 
 eel_lice_state::eel_lice_state(NSEEL_VMCTX vm, void *ctx, int image_slots, int font_slots)
 {
@@ -377,6 +455,8 @@ eel_lice_state::eel_lice_state(NSEEL_VMCTX vm, void *ctx, int image_slots, int f
 
   m_has_cap=0;
   m_has_had_getch=false;
+  m_last_menu_time = GetTickCount() - 100000;
+  m_last_menu_cnt = 0;
 }
 eel_lice_state::~eel_lice_state()
 {
@@ -387,16 +467,12 @@ eel_lice_state::~eel_lice_state()
   {
     LICE__Destroy(m_framebuffer_extra);
     LICE__Destroy(m_framebuffer);
-    int x;
-    for (x=0;x<m_gfx_images.GetSize();x++)
-    {
-      LICE__Destroy(m_gfx_images.Get()[x]);
-    }
   }
+  for (int x=0;x<m_gfx_images.GetSize();x++)
+    m_gfx_images.Get()[x].clear();
   if (LICE_FUNCTION_VALID(LICE__DestroyFont))
   {
-    int x;
-    for (x=0;x<m_gfx_fonts.GetSize();x++)
+    for (int x=0;x<m_gfx_fonts.GetSize();x++)
     {
       if (m_gfx_fonts.Get()[x].font) LICE__DestroyFont(m_gfx_fonts.Get()[x].font);
     }
@@ -964,7 +1040,7 @@ void eel_lice_state::gfx_getimgdim(EEL_F img, EEL_F *w, EEL_F *h)
   if (!LICE__GetWidth || !LICE__GetHeight) return;
 #endif
 
-  LICE_IBitmap *bm=GetImageForIndex(img,"gfx_getimgdim"); 
+  LICE_IBitmap *bm=GetImageForIndex(img,"gfx_getimgdim",false); 
   if (bm)
   {
     *w=LICE__GetWidth(bm);
@@ -992,6 +1068,31 @@ EEL_F eel_lice_state::gfx_getdropfile(void *opaque, int np, EEL_F **parms)
   return 1.0;
 }
 
+bool eel_lice_state::do_load_image(int img, const char *str)
+{
+  s_img_cache_mutex.Enter();
+  img_shared_state *s = s_img_cache.Get(str);
+  if (s)
+  {
+    wdl_atomic_incr(&s->refcnt);
+  }
+  else
+  {
+    s_img_cache_mutex.Leave();
+
+    LICE_IBitmap *bm = LICE_LoadImage(str,NULL,false);
+    if (!bm) return false;
+
+    s = new img_shared_state(bm);
+    s_img_cache_mutex.Enter();
+    s_img_cache.Insert(str,s);
+  }
+  s_img_cache_mutex.Leave();
+  m_gfx_images.Get()[img].clear(NULL,s);
+
+  return true;
+}
+
 EEL_F eel_lice_state::gfx_loadimg(void *opaque, int img, EEL_F loadFrom)
 {
 #ifdef DYNAMIC_LICE
@@ -1005,13 +1106,8 @@ EEL_F eel_lice_state::gfx_loadimg(void *opaque, int img, EEL_F loadFrom)
 
     if (ok && fs.GetLength())
     {
-      LICE_IBitmap *bm = LICE_LoadImage(fs.Get(),NULL,false);
-      if (bm)
-      {
-        LICE__Destroy(m_gfx_images.Get()[img]);
-        m_gfx_images.Get()[img]=bm;
+      if (do_load_image(img,fs.Get()))
         return img;
-      }
     }
   }
   return -1.0;
@@ -1034,10 +1130,11 @@ EEL_F eel_lice_state::gfx_setimgdim(int img, EEL_F *w, EEL_F *h)
   LICE_IBitmap *bm=NULL;
   if (img >= 0 && img < m_gfx_images.GetSize()) 
   {
-    bm=m_gfx_images.Get()[img];  
+    m_gfx_images.Get()[img].on_write();
+    bm=m_gfx_images.Get()[img].bm;
     if (!bm) 
     {
-      m_gfx_images.Get()[img] = bm = __LICE_CreateBitmap(1,use_w,use_h);
+      m_gfx_images.Get()[img].bm = bm = __LICE_CreateBitmap(1,use_w,use_h);
       rv=!!bm;
     }
     else 
@@ -1090,7 +1187,7 @@ void eel_lice_state::gfx_transformblit(EEL_F **parms, int div_w, int div_h, EEL_
 #endif 
     ) return;
 
-  LICE_IBitmap *bm=GetImageForIndex(parms[0][0],"gfx_transformblit:src"); 
+  LICE_IBitmap *bm=GetImageForIndex(parms[0][0],"gfx_transformblit:src",false); 
   if (!bm) return;
 
   const int bmw=LICE__GetWidth(bm);
@@ -1265,7 +1362,7 @@ void eel_lice_state::gfx_blitext2(int np, EEL_F **parms, int blitmode)
 #endif 
     ) return;
 
-  LICE_IBitmap *bm=GetImageForIndex(parms[0][0],"gfx_blitext2:src"); 
+  LICE_IBitmap *bm=GetImageForIndex(parms[0][0],"gfx_blitext2:src",false); 
   if (!bm) return;
 
   const int bmw=LICE__GetWidth(bm);
@@ -1347,7 +1444,7 @@ void eel_lice_state::gfx_blitext(EEL_F img, EEL_F *coords, EEL_F angle)
 #endif 
     ) return;
 
-  LICE_IBitmap *bm=GetImageForIndex(img,"gfx_blitext:src");
+  LICE_IBitmap *bm=GetImageForIndex(img,"gfx_blitext:src",false);
   if (!bm) return;
   
   SetImageDirty(dest);
@@ -1398,7 +1495,7 @@ void eel_lice_state::gfx_set(int np, EEL_F **parms)
 
 void eel_lice_state::gfx_getpixel(EEL_F *r, EEL_F *g, EEL_F *b)
 {
-  LICE_IBitmap *dest = GetImageForIndex(*m_gfx_dest,"gfx_getpixel");
+  LICE_IBitmap *dest = GetImageForIndex(*m_gfx_dest,"gfx_getpixel",false);
   if (!dest) return;
 
   int ret=LICE_FUNCTION_VALID(LICE_GetPixel)?LICE_GetPixel(dest,(int)*m_gfx_x, (int)*m_gfx_y):0;
@@ -1492,6 +1589,7 @@ static int __drawTextWithFont(LICE_IBitmap *dest, const RECT *rect, LICE_IFont *
       {
         case '\n': 
           ypos += 8; 
+          WDL_FALLTHROUGH;
         case '\r': 
           xpos = sxpos; 
         break;
@@ -1573,6 +1671,16 @@ EEL_F eel_lice_state::gfx_showmenu(void* opaque, EEL_F** parms, int nparms)
   const char* p=EEL_STRING_GET_FOR_INDEX(parms[0][0], NULL);
   if (!p || !p[0]) return 0.0;
 
+  if ((GetTickCount()-m_last_menu_time) < (m_last_menu_cnt>=5 ? 3000 : 500))
+  {
+    if (m_last_menu_cnt >= 5) return 0;
+    m_last_menu_cnt++;
+  }
+  else
+  {
+    m_last_menu_cnt=0;
+  }
+
   int id=1;
   HMENU hm=PopulateMenuFromStr(&p, &id);
 
@@ -1580,7 +1688,8 @@ EEL_F eel_lice_state::gfx_showmenu(void* opaque, EEL_F** parms, int nparms)
   if (hm)
   {
     POINT pt;
-    if (hwnd_standalone)
+    HWND par = hwnd_standalone;
+    if (par)
     {
 #ifdef __APPLE__
       if (*m_gfx_ext_retina > 1.0) 
@@ -1594,11 +1703,19 @@ EEL_F eel_lice_state::gfx_showmenu(void* opaque, EEL_F** parms, int nparms)
         pt.x = (short)*m_gfx_x;
         pt.y = (short)*m_gfx_y;
       }
-      ClientToScreen(hwnd_standalone, &pt);
+      ClientToScreen(par, &pt);
     }
     else
+    {
+#ifdef EEL_LICE_STANDALONE_PARENT
+      par = EEL_LICE_STANDALONE_PARENT(opaque);
+#endif
       GetCursorPos(&pt);
-    ret=TrackPopupMenu(hm, TPM_NONOTIFY|TPM_RETURNCMD, pt.x, pt.y, 0, hwnd_standalone, NULL);
+    }
+
+    ret=TrackPopupMenu(hm, TPM_NONOTIFY|TPM_RETURNCMD, pt.x, pt.y, 0, par, NULL);
+    m_last_menu_time = GetTickCount();
+    if (ret) m_last_menu_cnt = 0;
     DestroyMenu(hm);
   }
   return (EEL_F)ret;
@@ -1630,13 +1747,10 @@ EEL_F eel_lice_state::gfx_setcursor(void* opaque, EEL_F** parms, int nparms)
   if (chg)
   {
     m_cursor = NULL;
-    if (m_cursor_resid > 0)
-    {
-      if (!p || !*p) m_cursor = LoadCursor(NULL, MAKEINTRESOURCE(m_cursor_resid));
+    if (!p || !*p) m_cursor = m_cursor_resid > 0 ? LoadCursor(NULL, MAKEINTRESOURCE(m_cursor_resid)) : NULL;
 #ifdef EEL_LICE_LOADTHEMECURSOR
-      else m_cursor = EEL_LICE_LOADTHEMECURSOR(m_cursor_resid, p);
+    else m_cursor = EEL_LICE_LOADTHEMECURSOR(m_cursor_resid, p);
 #endif
-    }
 
     bool do_set = GetCapture() == hwnd_standalone;
     if (!do_set && GetFocus() == hwnd_standalone)
@@ -1712,7 +1826,6 @@ void eel_lice_state::gfx_drawstr(void *opaque, EEL_F **parms, int nparms, int fo
 
   if (s_len)
   {
-    SetImageDirty(dest);
     if (formatmode>=2)
     {
       if (nfmtparms==2)
@@ -1733,6 +1846,7 @@ void eel_lice_state::gfx_drawstr(void *opaque, EEL_F **parms, int nparms, int fo
         r.right=(int)*parms[2];
         r.bottom=(int)*parms[3];
       }
+      SetImageDirty(dest);
       *m_gfx_x=__drawTextWithFont(dest,&r,GetActiveFont(),s,s_len,
         getCurColor(),getCurMode(),(float)*m_gfx_a,flags,m_gfx_y,NULL);
     }
@@ -1997,21 +2111,40 @@ static EEL_F * NSEEL_CGEN_CALL _gfx_update(void *opaque, EEL_F *n)
 
 
 
-static EEL_F NSEEL_CGEN_CALL _gfx_getchar(void *opaque, EEL_F *p)
+static EEL_F NSEEL_CGEN_CALL _gfx_getchar(void *opaque, INT_PTR np, EEL_F **plist)
 {
   eel_lice_state *ctx=EEL_LICE_GET_CONTEXT(opaque);
+  if (np > 1) plist[1][0] = 0.0;
   if (ctx)
   {
+    EEL_F *p = plist[0];
     ctx->m_has_had_getch=true;
     if (*p >= 2.0)
     {
-      if (*p == 65536.0)
+      if (*p == 65536.0 || *p == 65537.0)
       {
         int rv = 1;
         if (ctx->hwnd_standalone)
         {
           if (ctx->hwnd_standalone==GetFocus()) rv|=2;
-          if (IsWindowVisible(ctx->hwnd_standalone)) rv|=4;
+          if (IsWindowVisible(ctx->hwnd_standalone))
+          {
+            rv|=4;
+            if (*p != 65537.0)
+            {
+              POINT pt;
+              GetCursorPos(&pt);
+              RECT r;
+              GetWindowRect(ctx->hwnd_standalone,&r);
+              if (r.top > r.bottom)
+              {
+                const int a = r.top;
+                r.top = r.bottom;
+                r.bottom = a;
+              }
+              if (PtInRect(&r,pt) && WindowFromPoint(pt) == ctx->hwnd_standalone) rv|=8;
+            }
+          }
         }
         return rv;
       }
@@ -2028,9 +2161,33 @@ static EEL_F NSEEL_CGEN_CALL _gfx_getchar(void *opaque, EEL_F *p)
     if (ctx->m_kb_queue_valid)
     {
       const int qsize = sizeof(ctx->m_kb_queue)/sizeof(ctx->m_kb_queue[0]);
-      const int a = ctx->m_kb_queue[ctx->m_kb_queue_pos & (qsize-1)];
+      int a = ctx->m_kb_queue[ctx->m_kb_queue_pos & (qsize-1)];
       ctx->m_kb_queue_pos++;
       ctx->m_kb_queue_valid--;
+
+#ifdef _WIN32
+      if (np > 1 && (a>>24) != 'u' && ctx->m_kb_queue_valid > 0)
+      {
+        int a2 = ctx->m_kb_queue[ctx->m_kb_queue_pos & (qsize-1)];
+        if ((a2>>24)=='u')
+        {
+          ctx->m_kb_queue_pos++;
+          ctx->m_kb_queue_valid--;
+          plist[1][0] = (a2&0xffffff);
+        }
+        return a;
+      }
+#else
+      if (a > 32 && a < 256 && np > 1)
+        plist[1][0] = a;
+#endif
+      if ((a>>24) == 'u')
+      {
+        if ((a&0xffffff) < 256)
+          a &= 0xff;
+        if (np > 1) plist[1][0] = a&0xffffff;
+      }
+
       return a;
     }
   }
@@ -2107,8 +2264,19 @@ static int eel_lice_key_xlate(int msg, int wParam, int lParam, bool *isAltOut)
         {
           const bool isctrl = !!(GetAsyncKeyState(VK_CONTROL)&0x8000);
           const bool isalt = !!(GetAsyncKeyState(VK_MENU)&0x8000);
+
+#ifdef __APPLE__
+          // SWELL_MacKeyToWindowsKeyEx maps control(FLWIN)+A-Z to 1-26
+          if (wParam > 0 && wParam <= 26 && !(lParam&FVIRTKEY))
+          {
+            *isAltOut=isalt;
+            return wParam;
+          }
+#endif
+
           if(isctrl || isalt)
           {
+
             if (wParam>='a' && wParam<='z') 
             {
               if (isctrl) wParam += 1-'a';
@@ -2124,12 +2292,6 @@ static int eel_lice_key_xlate(int msg, int wParam, int lParam, bool *isAltOut)
               return wParam;
             }
           }
-
-          if (isctrl)
-          {
-            if ((wParam&~0x80) == '[') return 27;
-            if ((wParam&~0x80) == ']') return 29;
-          }
         }
       break;
     }
@@ -2138,7 +2300,10 @@ static int eel_lice_key_xlate(int msg, int wParam, int lParam, bool *isAltOut)
   if(wParam>=32) 
   {
     #ifdef _WIN32
-      if (msg == WM_CHAR) return wParam;
+      if (msg == WM_CHAR)
+      {
+        return (wParam&0xffffff) | ('u'<<24); // windows encodes all wm_chars as 'u'<<24
+      }
     #else
       if (!(GetAsyncKeyState(VK_SHIFT)&0x8000))
       {
@@ -2149,6 +2314,8 @@ static int eel_lice_key_xlate(int msg, int wParam, int lParam, bool *isAltOut)
             wParam += 'a'-'A';
         }
       }
+      if (wParam >= 0x100)
+        return (wParam&0xffffff) | ('u'<<24);
       return wParam;
     #endif
   }      
@@ -2526,6 +2693,22 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
         return 0;
       }
     break;
+    case WM_USER+1001:
+      if (wParam == 0xdddd && lParam)
+      {
+        eel_lice_state *ctx=(eel_lice_state*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+        if (ctx)
+        {
+          ctx->m_ddrop_files.Empty(true,free);
+          const char *r = (const char *)lParam;
+          while (*r)
+          {
+            ctx->m_ddrop_files.Add(strdup(r));
+            r += strlen(r)+1;
+          }
+        }
+      }
+    return 0;
     case WM_DROPFILES:
       {
         eel_lice_state *ctx=(eel_lice_state*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
@@ -2566,21 +2749,26 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     case WM_CHAR:
       {
         eel_lice_state *ctx=(eel_lice_state*)GetWindowLongPtr(hwnd,GWLP_USERDATA);
+#ifdef __APPLE__
+        {
+          int f=0;
+          wParam = SWELL_MacKeyToWindowsKeyEx(NULL,&f,1);
+          lParam=f;
+        }
+#endif
 
         bool hadAltAdj=false;
         int a=eel_lice_key_xlate(uMsg,(int)wParam,(int)lParam, &hadAltAdj);
-#ifdef _WIN32
-        if (!a && (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP) && wParam >= 'A' && wParam <= 'Z') a=(int)wParam + 'a' - 'A';
-#endif
-        const int mask = hadAltAdj ? ~256 : ~0;
-
+        if (a == -1) return 0;
 #ifdef _WIN32
         if (!a && (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP))
         {
-          // not ideal, doesn't properly support all modifiers but better than nothing
-          a = (int)MapVirtualKey((UINT)wParam,2/*MAPVK_VK_TO_CHAR*/);
+          // will not end up in queue, just for state tracking
+          if (wParam >= 'A' && wParam <= 'Z') a=(int)wParam + 'a' - 'A';
+          else a = (int)MapVirtualKey((UINT)wParam,2/*MAPVK_VK_TO_CHAR*/);
         }
 #endif
+        const int mask = hadAltAdj ? ~256 : ~0;
 
         if (a & mask)
         {
@@ -2607,12 +2795,6 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
             st[zp]=lowera;
           }
         }
-#ifdef _WIN32
-        if (!a && (uMsg == WM_KEYDOWN || uMsg == WM_SYSKEYDOWN) && ((GetAsyncKeyState(VK_CONTROL)&0x8000)||(GetAsyncKeyState(VK_MENU)&0x8000)))
-        {
-          a = (int)MapVirtualKey((UINT)wParam,2/*MAPVK_VK_TO_CHAR*/);
-        }
-#endif
 
         if (a && uMsg != WM_KEYUP
 #ifdef _WIN32
@@ -2628,6 +2810,7 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
             ctx->m_kb_queue_pos++;
           }
           ctx->m_kb_queue[(ctx->m_kb_queue_pos + ctx->m_kb_queue_valid++) & (qsize-1)] = a;
+          if (ctx->m_last_menu_cnt && (GetTickCount()-ctx->m_last_menu_time)>250) ctx->m_last_menu_cnt = 0;
         }
 
       }
@@ -2660,6 +2843,7 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
           if (GetAsyncKeyState(VK_LWIN)&0x8000) f|=32;
 
           ctx->m_has_cap|=f;
+          if (ctx->m_last_menu_cnt && (GetTickCount()-ctx->m_last_menu_time)>250) ctx->m_last_menu_cnt = 0;
         }
       }
     }
@@ -2678,6 +2862,7 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
         }
         else 
         {
+          if (ctx->m_last_menu_cnt && (GetTickCount()-ctx->m_last_menu_time)>250) ctx->m_last_menu_cnt = 0;
           if (uMsg == WM_LBUTTONUP) ctx->m_has_cap &= ~0x10000;
           else if (uMsg == WM_RBUTTONUP) ctx->m_has_cap &= ~0x20000;
           else if (uMsg == WM_MBUTTONUP) ctx->m_has_cap &= ~0x40000;
@@ -2767,7 +2952,11 @@ LRESULT WINAPI eel_lice_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     return 0;
   }
 
+#ifdef _WIN32
+  return DefWindowProcW(hwnd,uMsg,wParam,lParam);
+#else
   return DefWindowProc(hwnd,uMsg,wParam,lParam);
+#endif
 }
 
 
@@ -2780,8 +2969,18 @@ void eel_lice_register_standalone(HINSTANCE hInstance, const char *classname, HW
   if (!reg)
   {
     eel_lice_hinstance=hInstance;
-    WNDCLASS wc={CS_DBLCLKS,eel_lice_wndproc,0,0,hInstance,icon,LoadCursor(NULL,IDC_ARROW), NULL, NULL,eel_lice_standalone_classname};
-    RegisterClass(&wc);
+    WCHAR tmp[256];
+    int x = 0;
+    while (eel_lice_standalone_classname[x])
+    {
+      if (WDL_NOT_NORMALLY(x == 255)) break;
+      tmp[x] = eel_lice_standalone_classname[x];
+      x++;
+    }
+    tmp[x]=0;
+
+    WNDCLASSW wc={CS_DBLCLKS,eel_lice_wndproc,0,0,hInstance,icon,LoadCursor(NULL,IDC_ARROW), NULL, NULL,tmp};
+    RegisterClassW(&wc);
     reg = true;
   }
 #endif
@@ -2804,7 +3003,7 @@ void eel_lice_register_standalone(HINSTANCE hInstance, const char *classname, HW
   NSEEL_addfunc_retptr("gfx_update",1,NSEEL_PProc_THIS,&_gfx_update);
 #endif
 
-  NSEEL_addfunc_retval("gfx_getchar",1,NSEEL_PProc_THIS,&_gfx_getchar);
+  NSEEL_addfunc_varparm("gfx_getchar",1,NSEEL_PProc_THIS,&_gfx_getchar);
 #endif
 }
 
@@ -2931,7 +3130,7 @@ static const char *eel_lice_function_reference =
   "\2"
   "\2\0"
 
-"gfx_getchar\t[char]\tIf char is 0 or omitted, returns a character from the keyboard queue, or 0 if no character is available, or -1 if the graphics window is not open. "
+"gfx_getchar\t[char, unichar]\tIf char is 0 or omitted, returns a character from the keyboard queue, or 0 if no character is available, or -1 if the graphics window is not open. "
      "If char is specified and nonzero, that character's status will be checked, and the function will return greater than 0 if it is pressed. Note that calling gfx_getchar() at least once causes mouse_cap to reflect keyboard modifiers even when the mouse is not captured.\n\n"
      "Common values are standard ASCII, such as 'a', 'A', '=' and '1', but for many keys multi-byte values are used, including 'home', 'up', 'down', 'left', 'rght', 'f1'.. 'f12', 'pgup', 'pgdn', 'ins', and 'del'. \n\n"
      "Modified and special keys can also be returned, including:\3\n"
@@ -2941,7 +3140,8 @@ static const char *eel_lice_function_reference =
      "\4" "27 for ESC\n"
      "\4" "13 for Enter\n"
      "\4' ' for space\n"
-     "\4" "65536 for query of special flags, returns: &1 (supported), &2=window has focus, &4=window is visible\n"
+     "\4" "65536 for query of special flags, returns: &1 (supported), &2=window has focus, &4=window is visible, &8=mouse click would hit window. 65537 queries special flags but does not do the mouse click hit testing (faster).\n"
+     "\4If unichar is specified, it will be set to the unicode value of the key if available (and the return value may be the unicode value or a raw key value as described above, depending). If unichar is not specified, unicode codepoints greater than 255 will be returned as 'u'<<24 + value\n"
      "\2\0"
     
   "gfx_showmenu\t\"str\"\tShows a popup menu at gfx_x,gfx_y. str is a list of fields separated by | characters. "
@@ -2955,7 +3155,7 @@ static const char *eel_lice_function_reference =
     "gfx_showmenu(\"first item, followed by separator||!second item, checked|>third item which spawns a submenu|#first item in submenu, grayed out|<second and last item in submenu|fourth item in top menu\")\0"  
   
 #ifdef EEL_LICE_LOADTHEMECURSOR
-  "gfx_setcursor\tresource_id,custom_cursor_name\tSets the mouse cursor. resource_id is a value like 32512 (for an arrow cursor), custom_cursor_name is a string description (such as \"arrow\") that will be override the resource_id, if available. In either case resource_id should be nonzero.\0"
+  "gfx_setcursor\tresource_id,custom_cursor_name\tSets the mouse cursor to resource_id and/or custom_cursor_name. \0" // REAPER has extended help elsewhere
 #else
   "gfx_setcursor\tresource_id\tSets the mouse cursor. resource_id is a value like 32512 (for an arrow cursor).\0"
 #endif

--- a/thirdparty/WDL/source/WDL/eel2/eel_pp.cpp
+++ b/thirdparty/WDL/source/WDL/eel2/eel_pp.cpp
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdarg.h>
+
+#include "../wdlstring.h"
+#include "../ptrlist.h"
+#include "eel_pproc.h"
+
+void NSEEL_HOSTSTUB_EnterMutex() { }
+void NSEEL_HOSTSTUB_LeaveMutex() { }
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    fprintf(stderr,"Usage: %s [scriptfile | -]\n",argv[0]);
+    return 1;
+  }
+  FILE *fp = strcmp(argv[1],"-") ? fopen(argv[1],"rb") : stdin;
+  if (!fp)
+  {
+    fprintf(stderr,"Error: could not open %s\n",argv[1]);
+    return 1;
+  }
+  WDL_FastString file_str, pp_str;
+  for (;;)
+  {
+    char buf[4096];
+    if (!fgets(buf,sizeof(buf),fp)) break;
+    file_str.Append(buf);
+  }
+  if (fp != stdin) fclose(fp);
+
+  EEL2_PreProcessor pproc;
+  const char *err = pproc.preprocess(file_str.Get(),&pp_str);
+  if (err)
+  {
+    fprintf(stderr,"Error: %s\n",err);
+    return 1;
+  }
+
+  printf("%s",pp_str.Get());
+
+  return 0;
+}

--- a/thirdparty/WDL/source/WDL/eel2/eel_pproc.h
+++ b/thirdparty/WDL/source/WDL/eel2/eel_pproc.h
@@ -1,0 +1,469 @@
+#ifndef _EEL2_PREPROC_H_
+#define _EEL2_PREPROC_H_
+#include "ns-eel-int.h"
+#include "../win32_utf8.h"
+
+#define EEL2_PREPROCESS_OPEN_TOKEN "<?"
+
+class EEL2_PreProcessor
+{
+  enum { LITERAL_BASE = 100000 };
+public:
+  EEL2_PreProcessor(int max_sz = 64<<20, int max_include_depth=20)
+  {
+    m_max_sz = max_sz;
+    m_fsout = NULL;
+    m_vm = NSEEL_VM_alloc();
+    m_max_include_depth = max_include_depth;
+    m_output_linecnt = 0;
+    m_cur_depth = 0;
+    NSEEL_VM_SetCustomFuncThis(m_vm, this);
+    NSEEL_VM_SetStringFunc(m_vm, addStringCallback, NULL);
+    if (!m_ftab.list_size)
+    {
+      NSEEL_addfunc_varparm_ex("printf",1,0,NSEEL_PProc_THIS,&pp_printf,&m_ftab);
+      NSEEL_addfunc_varparm_ex("include",1,1,NSEEL_PProc_THIS,&pp_include,&m_ftab);
+    }
+    NSEEL_VM_SetFunctionTable(m_vm, &m_ftab);
+    m_suppress = NSEEL_VM_regvar(m_vm, "_suppress");
+  }
+
+  void define(const char *name, double val)
+  {
+    EEL_F *v = NSEEL_VM_regvar(m_vm,name);
+    if (v) *v = val;
+  }
+
+  ~EEL2_PreProcessor()
+  {
+    for (int x = 0; x < m_code_handles.GetSize(); x ++)
+      NSEEL_code_free((NSEEL_CODEHANDLE) m_code_handles.Get(x));
+    m_literal_strings.Empty(true,free);
+    if (m_vm) NSEEL_VM_free(m_vm);
+    m_suppress = NULL;
+  }
+
+  void clear_line_info()
+  {
+    m_line_tab.Resize(0);
+  }
+  const char *preprocess(const char *str, WDL_FastString *fs)
+  {
+    if (!m_vm || !m_suppress)
+      return "preprocessor: memory error";
+    if (!m_cur_depth)
+    {
+      m_line_tab.Resize(0);
+      m_output_linecnt = 0;
+      *m_suppress = 0.0;
+    }
+    int input_linecnt = 0;
+    for (;;)
+    {
+      const bool suppress = m_suppress && *m_suppress > 0.0;
+
+      int lc = 0;
+      const char *tag = str;
+      while (*tag && strncmp(tag,EEL2_PREPROCESS_OPEN_TOKEN,2)) if (*tag++ == '\n') lc++;
+
+      if (lc)
+      {
+        input_linecnt += lc;
+        if (suppress)
+          add_line_inf(m_output_linecnt,lc);
+        else
+          m_output_linecnt += lc;
+      }
+
+      if (!*tag)
+      {
+        if (!suppress) fs->Append(str);
+        return NULL;
+      }
+      if (!suppress && tag > str) fs->Append(str,(int)(tag-str));
+
+      tag += 2;
+      while (*tag == ' ' || *tag == '\t') tag++;
+      str = tag;
+      lc = 0;
+      while (*str && strncmp(str,"?>",2)) if (*str++ == '\n') lc++;
+
+      if (!*str)
+      {
+        m_tmp.SetFormatted(512, "%d: unterminated preprocessor " EEL2_PREPROCESS_OPEN_TOKEN " block", input_linecnt+1);
+        return m_tmp.Get();
+      }
+
+      if (lc)
+      {
+        input_linecnt += lc;
+        add_line_inf(m_output_linecnt,lc);
+      }
+      if (str > tag)
+      {
+        m_tmp.Set(tag,(int)(str-tag));
+        NSEEL_CODEHANDLE ch = NSEEL_code_compile_ex(m_vm, m_tmp.Get(), 0, NSEEL_CODE_COMPILE_FLAG_COMMONFUNCS);
+        if (!ch)
+        {
+          const char *err = NSEEL_code_getcodeerror(m_vm);
+          if (err)
+          {
+            const int line_ref = atoi(err);
+            while (*err >= '0' && *err <= '9') err++;
+            m_tmp.SetFormatted(512,"%d: preprocessor%s%s",input_linecnt+line_ref,*err && *err != ':' ? ": ":"",err);
+            return m_tmp.Get();
+          }
+        }
+        else
+        {
+          lc = 0;
+          const int oldlen = fs->GetLength();
+          m_fsout = fs;
+          NSEEL_code_execute(ch);
+          m_fsout = NULL;
+          m_code_handles.Add(ch);
+          for (int x = oldlen; x < fs->GetLength(); x ++) if (fs->Get()[x] == '\n') lc++;
+          if (lc)
+          {
+            add_line_inf(m_output_linecnt,-lc);
+            m_output_linecnt += lc;
+          }
+        }
+      }
+      str += 2;
+    }
+  }
+
+  const char *translate_error_line(const char *err_line)
+  {
+    if (m_line_tab.GetSize()<2) return err_line;
+    int l = atoi(err_line)-1;
+    if (l<0) return err_line;
+
+    // tab is a list of pairs
+    // [<output position>, delta]
+    // delta>0 if input lines were skipped
+    // delta<0 if output lines were added
+
+    int nl = l;
+    for (int x = m_line_tab.GetSize()-2; x >= 0; x -= 2)
+    {
+      int p = m_line_tab.Get()[x];
+      if (nl > p)
+      {
+        int delta = m_line_tab.Get()[x+1];
+        nl += delta;
+        if (nl < p) nl = p;
+      }
+    }
+
+    if (l == nl) return err_line;
+
+    while (*err_line >= '0' && *err_line <= '9') err_line++;
+    if (*err_line == ':') err_line++;
+    m_tmp.SetFormatted(512,"%d:%s",1 + nl,err_line);
+    return m_tmp.Get();
+  }
+
+  NSEEL_VMCTX m_vm;
+  WDL_PtrList<char> m_literal_strings;
+  WDL_FastString m_tmp, *m_fsout;
+  WDL_TypedBuf<int> m_line_tab; // expose this in case the caller wants to keep copies around
+  EEL_F *m_suppress;
+  int m_max_sz;
+  int m_cur_depth, m_max_include_depth;
+  int m_output_linecnt;
+  static eel_function_table m_ftab;
+  WDL_PtrList<void> m_code_handles;
+  WDL_PtrList<const char> m_include_paths;
+
+  void add_line_inf(int output_linecnt, int lc)
+  {
+    if (!m_cur_depth)
+    {
+      m_line_tab.Add(output_linecnt); // log lc lines of input skipped
+      m_line_tab.Add(lc);
+    }
+  }
+
+  static EEL_F addStringCallback(void *opaque, struct eelStringSegmentRec *list)
+  {
+    EEL2_PreProcessor *_this = (EEL2_PreProcessor*)opaque;
+    if (!_this) return -1.0;
+
+    const int sz = nseel_stringsegments_tobuf(NULL,0,list);
+    char *ns = (char *)malloc(sz+1);
+    if (WDL_NOT_NORMALLY(!ns)) return -1.0;
+    nseel_stringsegments_tobuf(ns,sz,list);
+
+    const int nstr = _this->m_literal_strings.GetSize();
+    for (int x=0;x<nstr;x++)
+    {
+      char *s = _this->m_literal_strings.Get(x);
+      if (!strcmp(s,ns))
+      {
+        free(ns);
+        return x + LITERAL_BASE;
+      }
+    }
+    _this->m_literal_strings.Add(ns);
+    return nstr + LITERAL_BASE;
+  }
+
+  const char *GetString(EEL_F v)
+  {
+    if (v >= LITERAL_BASE && v < LITERAL_BASE + m_literal_strings.GetSize())
+      return m_literal_strings.Get((int) (v - LITERAL_BASE));
+    return NULL;
+  }
+
+  static int eel_validate_format_specifier(const char *fmt_in, char *typeOut,
+                                           char *fmtOut, int fmtOut_sz,
+                                           char *varOut, int varOut_sz,
+                                           int *varOut_used
+                                          )
+  {
+    const char *fmt = fmt_in+1;
+    int state=0;
+    if (fmt_in[0] != '%') return 0; // ugh passed a non-specifier
+
+    *varOut_used = 0;
+    *varOut = 0;
+
+    if (fmtOut_sz-- < 2) return 0;
+    *fmtOut++ = '%';
+
+    while (*fmt)
+    {
+      const char c = *fmt++;
+      if (fmtOut_sz < 2) return 0;
+
+      if (c == 'f'|| c=='e' || c=='E' || c=='g' || c=='G' || c == 'd' || c == 'u' ||
+          c == 'x' || c == 'X' || c == 'c' || c == 'C' || c =='s' || c=='S' || c=='i')
+      {
+        *typeOut = c;
+        fmtOut[0] = c;
+        fmtOut[1] = 0;
+        return (int) (fmt - fmt_in);
+      }
+      else if (c == '.')
+      {
+        *fmtOut++ = c; fmtOut_sz--;
+        if (state&(2)) break;
+        state |= 2;
+      }
+      else if (c == '+')
+      {
+        *fmtOut++ = c; fmtOut_sz--;
+        if (state&(32|16|8|4)) break;
+        state |= 8;
+      }
+      else if (c == '-' || c == ' ')
+      {
+        *fmtOut++ = c; fmtOut_sz--;
+        if (state&(32|16|8|4)) break;
+        state |= 16;
+      }
+      else if (c >= '0' && c <= '9')
+      {
+        *fmtOut++ = c; fmtOut_sz--;
+        state|=4;
+      }
+      else if (c == '{')
+      {
+        if (state & 64) break;
+        state|=64;
+        if (*fmt == '.' || (*fmt >= '0' && *fmt <= '9')) return 0; // symbol name can't start with 0-9 or .
+
+        while (*fmt != '}')
+        {
+          if ((*fmt >= 'a' && *fmt <= 'z') ||
+              (*fmt >= 'A' && *fmt <= 'Z') ||
+              (*fmt >= '0' && *fmt <= '9') ||
+              *fmt == '_' || *fmt == '.' || *fmt == '#')
+          {
+            if (varOut_sz < 2) return 0;
+            *varOut++ = *fmt++;
+            varOut_sz -- ;
+          }
+          else
+          {
+            return 0; // bad character in variable name
+          }
+        }
+        fmt++;
+        *varOut = 0;
+        *varOut_used=1;
+      }
+      else
+      {
+        break;
+      }
+    }
+    return 0;
+  }
+
+  static int eel_format_strings(void *opaque, const char *fmt, const char *fmt_end, char *buf, int buf_sz, int num_fmt_parms, EEL_F **fmt_parms)
+  {
+    EEL2_PreProcessor *_this = (EEL2_PreProcessor*)opaque;
+    int fmt_parmpos = 0;
+    char *op = buf;
+    while ((fmt_end ? fmt < fmt_end : *fmt) && op < buf+buf_sz-128)
+    {
+      if (fmt[0] == '%' && fmt[1] == '%')
+      {
+        *op++ = '%';
+        fmt+=2;
+      }
+      else if (fmt[0] == '%')
+      {
+        char ct=0;
+        char fs[128];
+        char varname[128];
+        int varname_used=0;
+        const int l=eel_validate_format_specifier(fmt,&ct,fs,sizeof(fs),varname,sizeof(varname),&varname_used);
+        if (!l || !ct)
+        {
+          *op=0;
+          return -1;
+        }
+
+        const EEL_F *varptr = NULL;
+        if (!varname_used)
+        {
+          if (fmt_parmpos < num_fmt_parms) varptr = fmt_parms[fmt_parmpos];
+          fmt_parmpos++;
+        }
+        double v = varptr ? (double)*varptr : 0.0;
+
+        if (ct == 's' || ct=='S')
+        {
+          const char *str = _this->GetString(v);
+          const int maxl=(int) (buf+buf_sz - 2 - op);
+          snprintf(op,maxl,fs,str ? str : "");
+        }
+        else
+        {
+          if (ct == 'x' || ct == 'X' || ct == 'd' || ct == 'u' || ct=='i')
+          {
+            snprintf(op,64,fs,(int) (v));
+          }
+          else if (ct == 'c')
+          {
+            *op++=(char) (int)v;
+            *op=0;
+          }
+          else if (ct == 'C')
+          {
+            const unsigned int iv = (unsigned int) v;
+            int bs = 0;
+            if (iv &      0xff000000) bs=24;
+            else if (iv & 0x00ff0000) bs=16;
+            else if (iv & 0x0000ff00) bs=8;
+            while (bs>=0)
+            {
+              const char c=(char) (iv>>bs);
+              *op++=c?c:' ';
+              bs-=8;
+            }
+            *op=0;
+          }
+          else
+          {
+            snprintf(op,64,fs,v);
+          }
+        }
+
+        while (*op) op++;
+
+        fmt += l;
+      }
+      else
+      {
+        *op++ = *fmt++;
+      }
+
+    }
+    *op=0;
+    return (int) (op - buf);
+  }
+
+  static EEL_F NSEEL_CGEN_CALL pp_printf(void *opaque, INT_PTR num_param, EEL_F **parms)
+  {
+    if (num_param>0 && opaque)
+    {
+      EEL2_PreProcessor *_this = (EEL2_PreProcessor*)opaque;
+      const char *fmt = _this->GetString(parms[0][0]);
+      if (fmt)
+      {
+        char buf[16384];
+        const int len = eel_format_strings(opaque,fmt,NULL,buf,(int)sizeof(buf), (int)num_param-1, parms+1);
+
+        if (len >= 0)
+        {
+          if (_this->m_fsout && _this->m_fsout->GetLength() < _this->m_max_sz)
+          {
+            _this->m_fsout->Append(buf,len);
+          }
+          return 1.0;
+        }
+      }
+    }
+    return 0.0;
+  }
+
+  static EEL_F NSEEL_CGEN_CALL pp_include(void *opaque, INT_PTR num_param, EEL_F **parms)
+  {
+    if (num_param>0 && opaque)
+    {
+      EEL2_PreProcessor *_this = (EEL2_PreProcessor*)opaque;
+      if (_this->m_cur_depth >= _this->m_max_include_depth) return -1.0;
+
+      const char *fn = _this->GetString(parms[0][0]);
+      if (!fn || !*fn) return -2.0;
+
+      WDL_FastString fullfn;
+      for (int x = _this->m_include_paths.GetSize()-1; x >= 0; x--)
+      {
+        const char *p = _this->m_include_paths.Get(x);
+        if (p && *p)
+        {
+          fullfn.Set(p);
+          fullfn.Append(WDL_DIRCHAR_STR);
+          fullfn.Append(fn);
+          FILE *fp = fopenUTF8(fullfn.Get(),"rb");
+          if (fp)
+          {
+            double rv = 0.0;
+            _this->m_cur_depth++;
+            fullfn.Set("");
+            while (fullfn.GetLength() < (4<<20))
+            {
+              char buf[512];
+              if (!fgets(buf,sizeof(buf),fp)) break;
+              fullfn.Append(buf);
+            }
+            fclose(fp);
+
+            WDL_FastString *outp = _this->m_fsout;
+            if (_this->preprocess(fullfn.Get(),outp))
+            {
+              rv = -3.0;
+            }
+            _this->m_fsout = outp;
+
+            _this->m_cur_depth--;
+            return rv;
+          }
+        }
+      }
+      return -4.0;
+    }
+    return 0.0;
+  }
+
+};
+
+eel_function_table EEL2_PreProcessor::m_ftab;
+
+#endif

--- a/thirdparty/WDL/source/WDL/eel2/eelscript.h
+++ b/thirdparty/WDL/source/WDL/eel2/eelscript.h
@@ -10,6 +10,7 @@
 #include "../wdlstring.h"
 #include "../assocarray.h"
 #include "../queue.h"
+#include "../mutex.h"
 #include "../win32_utf8.h"
 #include "ns-eel.h"
 
@@ -59,6 +60,10 @@ class eel_net_state;
 #endif
 #ifndef EELSCRIPT_NO_LICE
 class eel_lice_state;
+#endif
+
+#ifndef EELSCRIPT_NO_PREPROC
+#include "eel_pproc.h"
 #endif
 
 class eelScriptInst {
@@ -159,6 +164,10 @@ class eelScriptInst {
 
 
     WDL_StringKeyedArray<bool> m_loaded_fnlist; // imported file list (to avoid repeats)
+
+#ifndef EELSCRIPT_NO_PREPROC
+    EEL2_PreProcessor m_preproc;
+#endif
 };
 
 //#define EEL_STRINGS_MUTABLE_LITERALS
@@ -357,6 +366,23 @@ NSEEL_CODEHANDLE eelScriptInst::compile_code(const char *code, const char **err)
     *err = "EEL VM not initialized";
     return NULL;
   }
+
+#ifndef EELSCRIPT_NO_PREPROC
+  WDL_FastString str;
+  if (strstr(code,EEL2_PREPROCESS_OPEN_TOKEN))
+  {
+    const char *pperr = m_preproc.preprocess(code,&str);
+    if (pperr)
+    {
+      *err = pperr;
+      return NULL;
+    }
+    code = str.Get();
+  }
+  else
+    m_preproc.clear_line_info();
+#endif
+
   NSEEL_CODEHANDLE ch = NSEEL_code_compile_ex(m_vm, code, 0, NSEEL_CODE_COMPILE_FLAG_COMMONFUNCS);
   if (ch)
   {
@@ -365,6 +391,9 @@ NSEEL_CODEHANDLE eelScriptInst::compile_code(const char *code, const char **err)
     return ch;
   }
   *err = NSEEL_code_getcodeerror(m_vm);
+#ifndef EELSCRIPT_NO_PREPROC
+  if (*err) *err = m_preproc.translate_error_line(*err);
+#endif
   return NULL;
 }
 
@@ -372,13 +401,30 @@ int eelScriptInst::runcode(const char *codeptr, int showerr, const char *showerr
 {
   if (m_vm) 
   {
-    NSEEL_CODEHANDLE code = NSEEL_code_compile_ex(m_vm,codeptr,0,canfree ? 0 : NSEEL_CODE_COMPILE_FLAG_COMMONFUNCS);
+    const char *err = NULL;
+    NSEEL_CODEHANDLE code = NULL;
+#ifndef EELSCRIPT_NO_PREPROC
+    WDL_FastString str;
+    if (strstr(codeptr,EEL2_PREPROCESS_OPEN_TOKEN))
+    {
+      err = m_preproc.preprocess(codeptr,&str);
+      if (err) goto on_preproc_error;
+      codeptr = str.Get();
+    }
+    else
+      m_preproc.clear_line_info();
+#endif
+
+    code = NSEEL_code_compile_ex(m_vm,codeptr,0,canfree ? 0 : NSEEL_CODE_COMPILE_FLAG_COMMONFUNCS);
     if (code) m_string_context->update_named_vars(m_vm);
 
-    char *err;
     if (!code && (err=NSEEL_code_getcodeerror(m_vm)))
     {
       if (!ignoreEndOfInputChk && (NSEEL_code_geterror_flag(m_vm)&1)) return 1;
+#ifndef EELSCRIPT_NO_PREPROC
+      err = m_preproc.translate_error_line(err);
+on_preproc_error:
+#endif
       if (showerr) 
       {
 #ifdef EEL_STRING_DEBUGOUT
@@ -565,6 +611,12 @@ int eelScriptInst::loadfile(const char *fn, const char *callerfn, bool allowstdi
     return -1;
   }
 
+#ifndef EELSCRIPT_NO_PREPROC
+  WDL_FastString incpath(fn);
+  incpath.remove_filepart();
+  m_preproc.m_include_paths.Add(incpath.Get());
+#endif
+
   WDL_FastString code;
   char line[4096];
   for (;;)
@@ -591,7 +643,13 @@ int eelScriptInst::loadfile(const char *fn, const char *callerfn, bool allowstdi
   }
   if (fp != stdin) fclose(fp);
 
-  return runcode(code.Get(),callerfn ? 2 : 1, fn,false,true,!callerfn);
+  int rv = runcode(code.Get(),callerfn ? 2 : 1, fn,false,true,!callerfn);
+
+#ifndef EELSCRIPT_NO_PREPROC
+  m_preproc.m_include_paths.Delete(m_preproc.m_include_paths.GetSize()-1);
+#endif
+
+  return rv;
 }
 
 char *eelScriptInst::evalCacheGet(const char *str, NSEEL_CODEHANDLE *ch)

--- a/thirdparty/WDL/source/WDL/eel2/glue_arm.h
+++ b/thirdparty/WDL/source/WDL/eel2/glue_arm.h
@@ -217,7 +217,6 @@ static const double __consttab[] = {
     1.5,
   };
 
-__attribute__((target("arm")))
 static void eel_callcode32(INT_PTR bp, INT_PTR cp, INT_PTR rt) 
 {
   __asm__ volatile(

--- a/thirdparty/WDL/source/WDL/eel2/glue_port.h
+++ b/thirdparty/WDL/source/WDL/eel2/glue_port.h
@@ -1,6 +1,7 @@
 #ifndef _EEL_GLUE_PORTABLE_H_
 #define _EEL_GLUE_PORTABLE_H_
 
+#define GLUE_MOD_IS_64
 
 #define DECL_ASMFUNC(x) 
 #define GLUE_JMP_TYPE int
@@ -789,14 +790,14 @@ static void GLUE_CALL_CODE(INT_PTR bp, INT_PTR cp, INT_PTR rt)
       break;
       case EEL_BC_MOD:
         {
-          int a = (int) (fp_pop());
-          fp_top = a ? (EEL_F) ((int)fp_top % a) : 0.0;
+          int a = (int) fabs(fp_pop());
+          fp_top = a ? (EEL_F) (((WDL_INT64)fabs(fp_top)) % a) : 0.0;
         }
       break;
       case EEL_BC_MOD_OP:
         {
-          int a = (int) (fp_pop());
-          *p2 = a ? (EEL_F) ((int)*p2 % a) : 0.0;
+          int a = (int) fabs(fp_pop());
+          *p2 = a ? (EEL_F) (((WDL_INT64)fabs(*p2)) % a) : 0.0;
           p1=p2;
 
         }

--- a/thirdparty/WDL/source/WDL/eel2/glue_x86_64_sse.h
+++ b/thirdparty/WDL/source/WDL/eel2/glue_x86_64_sse.h
@@ -2,7 +2,7 @@
 #define _NSEEL_GLUE_X86_64_SSE_H_
 
 // SSE version (needs the appropriate .o linked!)
-
+#define GLUE_MOD_IS_64
 #define GLUE_PREFER_NONFP_DV_ASSIGNS
 #define GLUE_HAS_FPREG2 1
 

--- a/thirdparty/WDL/source/WDL/eel2/ns-eel-func-ref.h
+++ b/thirdparty/WDL/source/WDL/eel2/ns-eel-func-ref.h
@@ -41,6 +41,8 @@ const char *nseel_builtin_function_reference=
     "memset\toffset,value,length\tSets length items of memory at offset to value.\0"
     "mem_get_values\toffset, ...\tReads values from memory starting at offset into variables specified. Slower than regular memory reads for less than a few variables, faster for more than a few. Undefined behavior if used with more than 32767 variables.\0"
     "mem_set_values\toffset, ...\tWrites values to memory starting at offset from variables specified. Slower than regular memory writes for less than a few variables, faster for more than a few. Undefined behavior if used with more than 32767 variables.\0"
+    "mem_multiply_sum\tsrc1,src2,length\tCalculates the sum of the products of values pointed to by src1 and src2. If src1 is -1, then calculates the sum of squares of src2, if -2, the sum of the absolute values of src2, if -3, calculates the sum of the values of src2. Other negative values are undefined.\0"
+    "mem_insert_shuffle\tbuf,len,value\tShuffles contents of buf right by 1, inserts value at buf[0], returns previous buf[len-1].\0"
     "stack_push\t&value\tPushes value onto the user stack, returns a reference to the parameter.\0"
     "stack_pop\t&value\tPops a value from the user stack into value, or into a temporary buffer if value is not specified, and returns a reference to where the stack was popped. Note that no checking is done to determine if the stack is empty, and as such stack_pop() will never fail.\0"
     "stack_peek\tindex\tReturns a reference to the item on the top of the stack (if index is 0), or to the Nth item on the stack if index is greater than 0. \0"

--- a/thirdparty/WDL/source/WDL/eel2/ns-eel-int.h
+++ b/thirdparty/WDL/source/WDL/eel2/ns-eel-int.h
@@ -315,6 +315,8 @@ EEL_F * NSEEL_CGEN_CALL __NSEEL_RAM_MemSet(EEL_F **blocks,EEL_F *dest, EEL_F *v,
 EEL_F * NSEEL_CGEN_CALL __NSEEL_RAM_MemFree(void *blocks, EEL_F *which);
 EEL_F * NSEEL_CGEN_CALL __NSEEL_RAM_MemTop(void *blocks, EEL_F *which);
 EEL_F * NSEEL_CGEN_CALL __NSEEL_RAM_MemCpy(EEL_F **blocks,EEL_F *dest, EEL_F *src, EEL_F *lenptr);
+EEL_F NSEEL_CGEN_CALL __NSEEL_RAM_MemSumProducts(EEL_F **blocks,EEL_F *dest, EEL_F *src, EEL_F *lenptr);
+EEL_F NSEEL_CGEN_CALL __NSEEL_RAM_MemInsertShuffle(EEL_F **blocks,EEL_F *buf, EEL_F *len, EEL_F *value);
 EEL_F NSEEL_CGEN_CALL __NSEEL_RAM_Mem_SetValues(EEL_F **blocks, INT_PTR np, EEL_F **parms);
 EEL_F NSEEL_CGEN_CALL __NSEEL_RAM_Mem_GetValues(EEL_F **blocks, INT_PTR np, EEL_F **parms);
 

--- a/thirdparty/WDL/source/WDL/eel2/ns-eel.h
+++ b/thirdparty/WDL/source/WDL/eel2/ns-eel.h
@@ -155,6 +155,7 @@ EEL_F *NSEEL_VM_getramptr_noalloc(NSEEL_VMCTX ctx, unsigned int offs, int *valid
 
 // set 0 to query. returns actual value used (limits, granularity apply -- see NSEEL_RAM_BLOCKS)
 int NSEEL_VM_setramsize(NSEEL_VMCTX ctx, int maxent);
+void NSEEL_VM_preallocram(NSEEL_VMCTX ctx, int maxent); // maxent=-1 for all allocated
 
 
 struct eelStringSegmentRec {

--- a/thirdparty/WDL/source/WDL/eel2/nseel-cfunc.c
+++ b/thirdparty/WDL/source/WDL/eel2/nseel-cfunc.c
@@ -124,6 +124,8 @@ EEL_F NSEEL_CGEN_CALL nseel_int_rand(EEL_F f)
 #include "asm-nseel-ppc-gcc.c"
 #elif defined(__aarch64__)
 #include "asm-nseel-aarch64-gcc.c"
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
+// add asm-nseel-aarch64-msvc.obj / asm-nseel-arm64ec.obj to project
 #elif defined(__arm__)
 #include "asm-nseel-arm-gcc.c"
 #elif defined (_M_ARM) && _M_ARM  == 7

--- a/thirdparty/WDL/source/WDL/lineparse.h
+++ b/thirdparty/WDL/source/WDL/lineparse.h
@@ -42,12 +42,6 @@
 #define WDL_LINEPARSER_HAS_LINEPARSERINT
 #endif
 
-#ifdef WDL_LINEPARSE_ATOF
-  extern "C" double WDL_LINEPARSE_ATOF(const char *);
-#else
-  #define WDL_LINEPARSE_ATOF atof
-#endif
-
 #ifndef WDL_LINEPARSE_IMPL_ONLY
 class LineParserInt // version which does not have any temporary space for buffers (requires use of parseDestroyBuffer)
 {
@@ -64,6 +58,7 @@ class LineParserInt // version which does not have any temporary space for buffe
       const char *gettoken_str(int token) const;
       char gettoken_quotingchar(int token) const;
       int gettoken_enum(int token, const char *strlist) const; // null separated list
+      void insert_token_raw(int token, const char *p); // first character of p is quoting character!
     #endif
 
     void eattoken() { if (m_eat<m_nt) m_eat++; }
@@ -129,17 +124,8 @@ class LineParserInt // version which does not have any temporary space for buffe
         const char oldterm = *line;
         *line=0; // null terminate this token
 
-        if (m_nt >= (int) (sizeof(m_toklist_small)/sizeof(m_toklist_small[0])))
-        {
-          m_tokens = m_toklist_big.ResizeOK(m_nt+1,false);
-          if (!m_tokens) 
-          {
-            m_nt=0;
-            return -1;
-          }
-          if (m_nt == (int) (sizeof(m_toklist_small)/sizeof(m_toklist_small[0])))
-            memcpy(m_tokens,m_toklist_small,m_nt*sizeof(const char *));         
-        }
+        if (!adding_token_alloc()) return -1;
+
         m_tokens[m_nt++] = basep;
 
         if (!oldterm) 
@@ -173,7 +159,7 @@ class LineParserInt // version which does not have any temporary space for buffe
         buf[ot++]=c;
       }
       buf[ot] = 0;
-      return WDL_LINEPARSE_ATOF(buf);
+      return atof(buf);
     }
 
     int WDL_LINEPARSE_PREFIX gettoken_int(int token) const
@@ -225,6 +211,16 @@ class LineParserInt // version which does not have any temporary space for buffe
       return -1;
     }
 
+    void WDL_LINEPARSE_PREFIX insert_token_raw(int token, const char *p) // first character of p is quoting character!
+    {
+      if (WDL_NOT_NORMALLY((unsigned int)token > m_nt)) return;
+      if (WDL_NOT_NORMALLY(!adding_token_alloc())) return;
+      if ((unsigned int)token < m_nt)
+        memmove(m_tokens + token + 1, m_tokens + token, (m_nt-token) * sizeof(const char *));
+      m_tokens[token] = p+1;
+      m_nt++;
+    }
+
 #ifndef WDL_LINEPARSE_IMPL_ONLY
   private:
 #endif
@@ -236,6 +232,23 @@ class LineParserInt // version which does not have any temporary space for buffe
     
 #ifndef WDL_LINEPARSE_IMPL_ONLY
   protected:
+
+    bool adding_token_alloc()
+    {
+      if (m_nt < (int) (sizeof(m_toklist_small)/sizeof(m_toklist_small[0])))
+        return true;
+
+      m_tokens = m_toklist_big.ResizeOK(m_nt+1,false);
+      if (!m_tokens)
+      {
+        m_nt=0;
+        return false;
+      }
+      if (m_nt == (int) (sizeof(m_toklist_small)/sizeof(m_toklist_small[0])))
+        memcpy(m_tokens,m_toklist_small,m_nt*sizeof(const char *));
+
+      return true;
+    }
 
     WDL_TypedBuf<const char *> m_toklist_big;
 

--- a/thirdparty/WDL/source/WDL/utf8_extended.h
+++ b/thirdparty/WDL/source/WDL/utf8_extended.h
@@ -1,0 +1,40 @@
+#ifndef _WDL_UTF8_EXTENDED_H_
+#define _WDL_UTF8_EXTENDED_H_
+
+// these are latin-1 supplemental (first utf-8 byte must be 0xc3), pass second byte&~0x20, second byte
+#define WDL_IS_UTF8_BYTE2_LATIN1S_A(cc,ccf) ((cc) >= 0x80 && (cc) <= 0x85)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_C(cc,ccf) ((cc) == 0x87)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_E(cc,ccf) ((cc) >= 0x88 && (cc) <= 0x8b)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_I(cc,ccf) ((cc) >= 0x8c && (cc) <= 0x8f)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_N(cc,ccf) ((cc) == 0x91)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_O(cc,ccf) ((cc) >= 0x92 && (cc) <= 0x96)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_U(cc,ccf) ((cc) >= 0x99 && (cc) <= 0x9c)
+#define WDL_IS_UTF8_BYTE2_LATIN1S_Y(cc,ccf) ((cc) == 0x9d || (ccf) == 0x9f)
+
+// latin extended A
+#define WDL_IS_UTF8_EXT1A_A(b1, b2) ((b1)==0xc4 && (b2) >= 0x80 && (b2) <= 0x85)
+#define WDL_IS_UTF8_EXT1A_C(b1, b2) ((b1)==0xc4 && (b2) >= 0x86 && (b2) <= 0x8D)
+#define WDL_IS_UTF8_EXT1A_D(b1, b2) ((b1)==0xc4 && (b2) >= 0x8E && (b2) <= 0x91)
+#define WDL_IS_UTF8_EXT1A_E(b1, b2) ((b1)==0xc4 && (b2) >= 0x92 && (b2) <= 0x9B)
+#define WDL_IS_UTF8_EXT1A_G(b1, b2) ((b1)==0xc4 && (b2) >= 0x9C && (b2) <= 0xa3)
+#define WDL_IS_UTF8_EXT1A_H(b1, b2) ((b1)==0xc4 && (b2) >= 0xa4 && (b2) <= 0xa7)
+#define WDL_IS_UTF8_EXT1A_I(b1, b2) ((b1)==0xc4 && (b2) >= 0xa8 && (b2) <= 0xb1)
+#define WDL_IS_UTF8_EXT1A_J(b1, b2) ((b1)==0xc4 && (b2) >= 0xb4 && (b2) <= 0xb5)
+#define WDL_IS_UTF8_EXT1A_K(b1, b2) ((b1)==0xc4 && (b2) >= 0xb6 && (b2) <= 0xb8)
+#define WDL_IS_UTF8_EXT1A_L(b1, b2) ((b1)==0xc4 ? ((b2) >= 0xb9 && (b2) <= 0xbf) : \
+                                ((b1)==0xc5 && (b2) >= 0x80 && (b2) <= 0x82))
+#define WDL_IS_UTF8_EXT1A_N(b1, b2) ((b1)==0xc5 && (b2) >= 0x83 && (b2) <= 0x89)
+#define WDL_IS_UTF8_EXT1A_O(b1, b2) ((b1)==0xc5 && (b2) >= 0x8c && (b2) <= 0x91)
+#define WDL_IS_UTF8_EXT1A_R(b1, b2) ((b1)==0xc5 && (b2) >= 0x94 && (b2) <= 0x99)
+#define WDL_IS_UTF8_EXT1A_S(b1, b2) ((b1)==0xc5 && (b2) >= 0x9a && (b2) <= 0xa1)
+#define WDL_IS_UTF8_EXT1A_T(b1, b2) ((b1)==0xc5 && (b2) >= 0xa2 && (b2) <= 0xa7)
+#define WDL_IS_UTF8_EXT1A_U(b1, b2) ((b1)==0xc5 && (b2) >= 0xa8 && (b2) <= 0xb3)
+#define WDL_IS_UTF8_EXT1A_W(b1, b2) ((b1)==0xc5 && (b2) >= 0xb4 && (b2) <= 0xb5)
+#define WDL_IS_UTF8_EXT1A_Y(b1, b2) ((b1)==0xc5 && (b2) >= 0xb6 && (b2) <= 0xb8)
+#define WDL_IS_UTF8_EXT1A_Z(b1, b2) ((b1)==0xc5 && (b2) >= 0xb9 && (b2) <= 0xbe)
+
+// U+300..U+36F are combining accents and get filtered/ignored
+#define WDL_IS_UTF8_SKIPPABLE(ca, nextc) \
+       (((((ca)&~1) == 0xCC) && ((nextc) >= 0x80 && (nextc) < ((ca) == 0xCD ? 0xAF : 0xc0))) ? 2 : 0)
+
+#endif

--- a/thirdparty/WDL/source/WDL/wdlcstring.h
+++ b/thirdparty/WDL/source/WDL/wdlcstring.h
@@ -31,6 +31,7 @@ C string manipulation utilities -- [v]snprintf for Win32, also snprintf_append, 
 #include <ctype.h>
 
 #include "wdltypes.h"
+#include "utf8_extended.h"
 
 #ifdef _WDL_CSTRING_IMPL_ONLY_
   #ifdef _WDL_CSTRING_IF_ONLY_
@@ -73,6 +74,9 @@ extern "C" {
 #ifndef WDL_STRCMP_LOGICAL_EX_FLAG_OLDSORT
 #define WDL_STRCMP_LOGICAL_EX_FLAG_OLDSORT 1
 #endif
+#ifndef WDL_STRCMP_LOGICAL_EX_FLAG_UTF8CONVERT
+#define WDL_STRCMP_LOGICAL_EX_FLAG_UTF8CONVERT 2
+#endif
 
 #ifdef _WDL_CSTRING_IF_ONLY_
 
@@ -89,6 +93,7 @@ extern "C" {
   size_t WDL_remove_trailing_crlf(char *str); // returns new length
   size_t WDL_remove_trailing_whitespace(char *str); // returns new length, removes crlf space tab
   const char *WDL_sanitize_ini_key_start(const char *p); // used for sanitizing the start of the "key" parameter to Write/GetPrivateProfile*. note does not fully santiize
+  char *WDL_sanitize_ini_key_full(const char *p, char *buf, int bufsz, int extra_filters); // converts = and leading [ to _. removes leading/trailing whitespace. if extra_filters&1, converts all [] to _.
 
   char *WDL_remove_trailing_decimal_zeros(char *str, unsigned int keep); // returns pointer to decimal point or end of string. removes final zeros after final decimal point only, keep=0 makes min length X, keep=1 X., keep=2 X.0, keep=3 X.00 etc, and also treats commas as decimal points
 
@@ -265,6 +270,21 @@ extern "C" {
     return p;
   }
 
+  _WDL_CSTRING_PREFIX char *WDL_sanitize_ini_key_full(const char *p, char *buf, int bufsz, int extra_filters)
+  {
+    // converts = and leading [ to _. removes leading/trailing whitespace. if extra_filters&1, converts all [] to _.
+    char *w=buf;
+    lstrcpyn_safe(buf,WDL_sanitize_ini_key_start(p),bufsz);
+    while (*w)
+    {
+      if (*w == '=' || ((extra_filters&1) && (*w=='[' || *w == ']'))) *w = '_';
+      w++;
+    }
+    while (w > buf && (w[-1] == ' ' || w[-1] == '\t' || w[-1] == '\r' || w[-1] == '\n')) *--w = 0;
+    while (--w >= buf) if (*w == '\r' || *w == '\n' || *w == '\t') *w = '_';
+    return buf;
+  }
+
   _WDL_CSTRING_PREFIX void WDL_VARARG_WARN(printf,3,4) snprintf_append(char *o, INT_PTR count, const char *format, ...)
   {
     if (count>0)
@@ -286,10 +306,61 @@ extern "C" {
     }
   }
 
-  static WDL_STATICFUNC_UNUSED int logical_char_order(int ch, int case_sensitive)
+  static WDL_STATICFUNC_UNUSED int logical_char_order(int ch, int case_sensitive, int flags, const unsigned char **ptr)
   {
     // _-<>etc, numbers, utf-8 chars, alpha chars
-    if (ch<0) return ch + 384; // utf-8 maps to 256..383
+    if (ch<0)
+    {
+      if (!(flags & WDL_STRCMP_LOGICAL_EX_FLAG_UTF8CONVERT)) return ch + 384;
+      for (;;)
+      {
+        int skip;
+        ch = **ptr;
+        skip = WDL_IS_UTF8_SKIPPABLE(ch, (*ptr)[1]);
+        if (!skip) break;
+        *ptr += skip;
+      }
+      if (ch == 0xc3)
+      {
+        const int ccf = (*ptr)[1];
+        const int cc = ccf & ~0x20;
+        if (WDL_IS_UTF8_BYTE2_LATIN1S_A(cc,ccf)) ch = (ccf&0x20) ? 'a' : 'A';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_C(cc,ccf)) ch = (ccf&0x20) ? 'c' : 'C';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_E(cc,ccf)) ch = (ccf&0x20) ? 'e' : 'E';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_I(cc,ccf)) ch = (ccf&0x20) ? 'i' : 'I';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_N(cc,ccf)) ch = (ccf&0x20) ? 'n' : 'N';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_O(cc,ccf)) ch = (ccf&0x20) ? 'o' : 'O';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_U(cc,ccf)) ch = (ccf&0x20) ? 'u' : 'U';
+        else if (WDL_IS_UTF8_BYTE2_LATIN1S_Y(cc,ccf)) ch = (ccf!=0x9d) ? 'y' : 'Y';
+      }
+      else if (ch == 0xc4 || ch == 0xc5)
+      {
+        const int nc = (*ptr)[1];
+        if (WDL_IS_UTF8_EXT1A_A(ch,nc)) ch = (nc&1) ? 'a' : 'A';
+        else if (WDL_IS_UTF8_EXT1A_C(ch,nc)) ch = (nc&1) ? 'c' : 'C';
+        else if (WDL_IS_UTF8_EXT1A_D(ch,nc)) ch = (nc&1) ? 'd' : 'D';
+        else if (WDL_IS_UTF8_EXT1A_E(ch,nc)) ch = (nc&1) ? 'e' : 'E';
+        else if (WDL_IS_UTF8_EXT1A_G(ch,nc)) ch = (nc&1) ? 'g' : 'G';
+        else if (WDL_IS_UTF8_EXT1A_H(ch,nc)) ch = (nc&1) ? 'h' : 'H';
+        else if (WDL_IS_UTF8_EXT1A_I(ch,nc)) ch = (nc&1) ? 'i' : 'I';
+        else if (WDL_IS_UTF8_EXT1A_J(ch,nc)) ch = (nc&1) ? 'j' : 'J';
+        else if (WDL_IS_UTF8_EXT1A_K(ch,nc)) ch = nc != 0xb6 ? 'k' : 'K';
+        else if (WDL_IS_UTF8_EXT1A_L(ch,nc)) ch = (nc&1) ? 'L' : 'l';
+        else if (WDL_IS_UTF8_EXT1A_N(ch,nc)) ch = (nc < 0x89 ? (nc&1) : !(nc&1)) ? 'N' : 'n';
+        else if (WDL_IS_UTF8_EXT1A_O(ch,nc)) ch = (nc&1) ? 'o' : 'O';
+        else if (WDL_IS_UTF8_EXT1A_R(ch,nc)) ch = (nc&1) ? 'r' : 'R';
+        else if (WDL_IS_UTF8_EXT1A_S(ch,nc)) ch = (nc&1) ? 's' : 'S';
+        else if (WDL_IS_UTF8_EXT1A_T(ch,nc)) ch = (nc&1) ? 't' : 'T';
+        else if (WDL_IS_UTF8_EXT1A_U(ch,nc)) ch = (nc&1) ? 'u' : 'U';
+        else if (WDL_IS_UTF8_EXT1A_W(ch,nc)) ch = (nc&1) ? 'w' : 'W';
+        else if (WDL_IS_UTF8_EXT1A_Y(ch,nc)) ch = (nc&1) ? 'y' : 'Y';
+        else if (WDL_IS_UTF8_EXT1A_Z(ch,nc)) ch = (nc&1) ? 'Z' : 'z';
+      }
+      if (ch >= 0x80) return ch + 128; // unknown utf-8 maps to 256..383
+      if (!ch) return 0;
+
+      *ptr += 1;
+    }
     if (ch >= '0' && ch <= '9') return ch + 128; // numbers map to 128+'0' etc
     if (ch >= 'A' && ch <= 'Z') return ch + 384; // alpha goes to 384+'A' or 384+'a' if not ignoring case
     if (ch >= 'a' && ch <= 'z') return case_sensitive ? (ch + 384) : (ch + 'A' - 'a' + 384);
@@ -323,7 +394,7 @@ extern "C" {
       }
       else
       {
-        int c1 = *s1++, c2 = *s2++;
+        int c1 = *s1, c2 = *s2;
         if (c1 != c2)
         {
           if (flags & WDL_STRCMP_LOGICAL_EX_FLAG_OLDSORT)
@@ -336,12 +407,15 @@ extern "C" {
           }
           else
           {
-            c1 = logical_char_order(c1, case_sensitive);
-            c2 = logical_char_order(c2, case_sensitive);
+            c1 = logical_char_order(c1, case_sensitive, flags, (const unsigned char **)&s1);
+            c2 = logical_char_order(c2, case_sensitive, flags, (const unsigned char **)&s2);
+            if (!c1) return c1-c2;
           }
           if (c1 != c2) return c1-c2;
         }
         else if (!c1) return 0;
+        s1++;
+        s2++;
       }
     }
   }

--- a/thirdparty/WDL/source/WDL/wdltypes.h
+++ b/thirdparty/WDL/source/WDL/wdltypes.h
@@ -44,6 +44,7 @@ typedef unsigned long long WDL_UINT64;
 typedef intptr_t INT_PTR;
 typedef uintptr_t UINT_PTR;
 #endif
+#include <string.h>
 
 #if defined(__ppc__) || !defined(__cplusplus)
 typedef char WDL_bool;
@@ -71,6 +72,18 @@ typedef bool WDL_bool;
 #define GCLP_HICONSM GCL_HICONSM
 #define SetClassLongPtr(a,b,c) SetClassLong(a,b,c)
 #define GetClassLongPtr(a,b) GetClassLong(a,b)
+#endif
+
+#if !defined(WDL_BIG_ENDIAN) && !defined(WDL_LITTLE_ENDIAN)
+  #ifdef __ppc__
+    #define WDL_BIG_ENDIAN
+  #else
+    #define WDL_LITTLE_ENDIAN
+  #endif
+#endif
+
+#if defined(WDL_BIG_ENDIAN) && defined(WDL_LITTLE_ENDIAN)
+#error WDL_BIG_ENDIAN and WDL_LITTLE_ENDIAN both defined
 #endif
 
 
@@ -106,7 +119,7 @@ typedef bool WDL_bool;
 #define wdl_max(x,y) ((x)<(y)?(y):(x))
 #define wdl_min(x,y) ((x)<(y)?(x):(y))
 #define wdl_abs(x) ((x)<0 ? -(x) : (x))
-#define wdl_clamp(x,minv,maxv) ((x) < (minv) ? (minv) : ((x) > (maxv) ? (maxv) : (x)))
+#define wdl_clamp(x,minv,maxv) (WDL_NOT_NORMALLY((maxv) < (minv)) || (x) < (minv) ? (minv) : ((x) > (maxv) ? (maxv) : (x)))
 #endif
 
 #ifndef _WIN32
@@ -177,6 +190,15 @@ typedef bool WDL_bool;
   #define WDL_NOT_NORMALLY(x) WDL_unlikely(x)
 #endif
 
+#if __GNUC__ >= 7 || __clang_major__ > 9
+  #if __has_attribute(__fallthrough__)
+    #define WDL_FALLTHROUGH __attribute__((__fallthrough__))
+  #endif
+#endif
+
+#ifndef WDL_FALLTHROUGH
+#define WDL_FALLTHROUGH do { } while(0)
+#endif
 
 typedef unsigned int WDL_TICKTYPE;
 
@@ -235,5 +257,82 @@ typedef char wdl_assert_failed_unsigned_char[((char)-1) > 0 ? -1 : 1];
 #else
   #define wdl_log printf
 #endif
+
+static void WDL_STATICFUNC_UNUSED wdl_bswap_copy(void *bout, const void *bin, size_t nelem, size_t elemsz)
+{
+  char p[8], po[8];
+  WDL_ASSERT(elemsz > 0);
+  if (elemsz > 1 && WDL_NORMALLY(elemsz <= sizeof(p)))
+  {
+    size_t i,x;
+    for (i = 0; i < nelem; i ++)
+    {
+      memcpy(p,bin,elemsz);
+      for (x = 0; x < elemsz; x ++) po[x]=p[elemsz-1-x];
+      memcpy(bout,po,elemsz);
+      bin = (const char *)bin + elemsz;
+      bout = (char *)bout + elemsz;
+    }
+  }
+  else if (bout != bin)
+    memmove(bout,bin,elemsz * nelem);
+}
+
+static void WDL_STATICFUNC_UNUSED wdl_memcpy_le(void *bout, const void *bin, size_t nelem, size_t elemsz)
+{
+  WDL_ASSERT(elemsz > 0 && elemsz <= 8);
+#ifdef WDL_BIG_ENDIAN
+  if (elemsz > 1) wdl_bswap_copy(bout,bin,nelem,elemsz);
+  else
+#endif
+  if (bout != bin) memmove(bout,bin,elemsz * nelem);
+}
+
+static void WDL_STATICFUNC_UNUSED wdl_memcpy_be(void *bout, const void *bin, size_t nelem, size_t elemsz)
+{
+  WDL_ASSERT(elemsz > 0 && elemsz <= 8);
+#ifdef WDL_LITTLE_ENDIAN
+  if (elemsz > 1) wdl_bswap_copy(bout,bin,nelem,elemsz);
+  else
+#endif
+  if (bout != bin) memmove(bout,bin,elemsz * nelem);
+}
+
+static void WDL_STATICFUNC_UNUSED wdl_mem_store_int(void *bout, int v)
+{
+  memcpy(bout,&v,sizeof(v));
+}
+
+static void WDL_STATICFUNC_UNUSED wdl_mem_store_int_le(void *bout, int v)
+{
+  wdl_memcpy_le(bout,&v,1,sizeof(v));
+}
+
+static void WDL_STATICFUNC_UNUSED wdl_mem_store_int_be(void *bout, int v)
+{
+  wdl_memcpy_be(bout,&v,1,sizeof(v));
+}
+
+static int WDL_STATICFUNC_UNUSED wdl_mem_load_int(const void *rd)
+{
+  int v;
+  memcpy(&v,rd,sizeof(v));
+  return v;
+}
+
+static int WDL_STATICFUNC_UNUSED wdl_mem_load_int_le(const void *rd)
+{
+  int v;
+  wdl_memcpy_le(&v,rd,1,sizeof(v));
+  return v;
+}
+
+static int WDL_STATICFUNC_UNUSED wdl_mem_load_int_be(const void *rd)
+{
+  int v;
+  wdl_memcpy_be(&v,rd,1,sizeof(v));
+  return v;
+}
+
 
 #endif

--- a/thirdparty/WDL/source/WDL/win32_utf8.c
+++ b/thirdparty/WDL/source/WDL/win32_utf8.c
@@ -17,7 +17,9 @@ extern "C" {
 
 
 #ifndef WDL_UTF8_MAXFNLEN
-#define WDL_UTF8_MAXFNLEN 2048
+  // only affects calls to GetCurrentDirectoryUTF8() and a few others
+  // could make them all dynamic using WIDETOMB_ALLOC() but meh the callers probably never pass more than 4k anyway
+#define WDL_UTF8_MAXFNLEN 4096
 #endif
 
 #define MBTOWIDE(symbase, src) \
@@ -86,16 +88,28 @@ static ATOM s_combobox_atom;
 
 int GetWindowTextUTF8(HWND hWnd, LPTSTR lpString, int nMaxCount)
 {
-  if (!lpString) return 0;
+  if (WDL_NOT_NORMALLY(!lpString || nMaxCount < 1)) return 0;
+  if (WDL_NOT_NORMALLY(hWnd == NULL))
+  {
+    *lpString = 0;
+    return 0;
+  }
   if (nMaxCount>0 AND_IS_NOT_WIN9X)
   {
     int alloc_size=nMaxCount;
+    LPARAM restore_wndproc = 0;
 
     // if a hooked combo box, and has an edit child, ask it directly
     if (s_combobox_atom && s_combobox_atom == GetClassWord(hWnd,GCW_ATOM) && GetProp(hWnd,WDL_UTF8_OLDPROCPROP))
     {
       HWND h2=FindWindowEx(hWnd,NULL,"Edit",NULL);
-      if (h2) hWnd=h2;
+      if (h2)
+      {
+        LPARAM resp = (LPARAM) GetProp(h2,WDL_UTF8_OLDPROCPROP);
+        if (resp)
+          restore_wndproc = SetWindowLongPtr(h2,GWLP_WNDPROC,resp);
+        hWnd=h2;
+      }
       else
       {
         // get via selection
@@ -145,9 +159,14 @@ int GetWindowTextUTF8(HWND hWnd, LPTSTR lpString, int nMaxCount)
 
         WIDETOMB_FREE(wbuf);
 
+        if (restore_wndproc)
+          SetWindowLongPtr(hWnd,GWLP_WNDPROC,restore_wndproc);
+
         return (int)strlen(lpString);
       }
     }
+    if (restore_wndproc)
+      SetWindowLongPtr(hWnd,GWLP_WNDPROC,restore_wndproc);
   }
   return GetWindowTextA(hWnd,lpString,nMaxCount);
 }
@@ -155,7 +174,9 @@ int GetWindowTextUTF8(HWND hWnd, LPTSTR lpString, int nMaxCount)
 UINT GetDlgItemTextUTF8(HWND hDlg, int nIDDlgItem, LPTSTR lpString, int nMaxCount)
 {
   HWND h = GetDlgItem(hDlg,nIDDlgItem);
-  if (h) return GetWindowTextUTF8(h,lpString,nMaxCount);
+  if (WDL_NORMALLY(h!=NULL)) return GetWindowTextUTF8(h,lpString,nMaxCount);
+  if (lpString && nMaxCount > 0)
+    *lpString = 0;
   return 0;
 }
 
@@ -163,7 +184,11 @@ UINT GetDlgItemTextUTF8(HWND hDlg, int nIDDlgItem, LPTSTR lpString, int nMaxCoun
 BOOL SetDlgItemTextUTF8(HWND hDlg, int nIDDlgItem, LPCTSTR lpString)
 {
   HWND h = GetDlgItem(hDlg,nIDDlgItem);
-  if (!h) return FALSE;
+  if (WDL_NOT_NORMALLY(!h)) return FALSE;
+
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpString)) return FALSE;
+#endif
 
   if (WDL_HasUTF8(lpString) AND_IS_NOT_WIN9X)
   {
@@ -200,12 +225,17 @@ static LRESULT WINAPI __forceUnicodeWndProc(HWND hwnd, UINT uMsg, WPARAM wParam,
 
 BOOL SetWindowTextUTF8(HWND hwnd, LPCTSTR str)
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!hwnd || !str)) return FALSE;
+#endif
   if (WDL_HasUTF8(str) AND_IS_NOT_WIN9X)
   {
     DWORD pid;
     if (GetWindowThreadProcessId(hwnd,&pid) == GetCurrentThreadId() && 
         pid == GetCurrentProcessId() && 
-        !(GetWindowLong(hwnd,GWL_STYLE)&WS_CHILD))
+        !IsWindowUnicode(hwnd) &&
+        !(GetWindowLong(hwnd,GWL_STYLE)&WS_CHILD)
+        )
     {
       LPARAM tmp = SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LPARAM)__forceUnicodeWndProc);
       BOOL rv = SetWindowTextA(hwnd, str);
@@ -428,6 +458,9 @@ BOOL GetSaveFileNameUTF8(LPOPENFILENAME lpofn)
 
 BOOL SHGetSpecialFolderPathUTF8(HWND hwndOwner, LPTSTR lpszPath, int pszPathLen, int csidl, BOOL create)
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpszPath)) return 0;
+#endif
   if (lpszPath AND_IS_NOT_WIN9X)
   {
     WCHAR tmp[4096];
@@ -446,6 +479,9 @@ BOOL SHGetPathFromIDListUTF8(const struct _ITEMIDLIST __unaligned *pidl, LPSTR p
 BOOL SHGetPathFromIDListUTF8(const struct _ITEMIDLIST *pidl, LPSTR pszPath, int pszPathLen)
 #endif
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!pszPath)) return FALSE;
+#endif
   if (pszPath AND_IS_NOT_WIN9X)
   {
     const int alloc_sz = pszPathLen < 4096 ? 4096 : pszPathLen;
@@ -466,6 +502,9 @@ BOOL SHGetPathFromIDListUTF8(const struct _ITEMIDLIST *pidl, LPSTR pszPath, int 
 
 struct _ITEMIDLIST *SHBrowseForFolderUTF8(struct _browseinfoA *bi)
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!bi)) return NULL;
+#endif
   if (bi && (WDL_HasUTF8(bi->pszDisplayName) || WDL_HasUTF8(bi->lpszTitle)) AND_IS_NOT_WIN9X)
   {
     MBTOWIDE(wfn,bi->pszDisplayName);
@@ -644,6 +683,9 @@ BOOL CopyFileUTF8(LPCTSTR existfn, LPCTSTR newfn, BOOL fie)
 
 DWORD GetModuleFileNameUTF8(HMODULE hModule, LPTSTR lpBuffer, DWORD nBufferLength)
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpBuffer||!nBufferLength)) return 0;
+#endif
   if (lpBuffer && nBufferLength > 1 AND_IS_NOT_WIN9X)
   {
 
@@ -658,6 +700,77 @@ DWORD GetModuleFileNameUTF8(HMODULE hModule, LPTSTR lpBuffer, DWORD nBufferLengt
   return GetModuleFileNameA(hModule,lpBuffer,nBufferLength);
 }
 
+DWORD GetLongPathNameUTF8(LPCTSTR lpszShortPath, LPSTR lpszLongPath, DWORD cchBuffer)
+{
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpszShortPath || !lpszLongPath || !cchBuffer)) return 0;
+#endif
+  if (lpszShortPath && lpszLongPath && cchBuffer > 1 AND_IS_NOT_WIN9X)
+  {
+    MBTOWIDE(sbuf,lpszShortPath);
+    if (sbuf_ok)
+    {
+      WCHAR wbuf[WDL_UTF8_MAXFNLEN];
+      wbuf[0]=0;
+      if (GetLongPathNameW(sbuf,wbuf,WDL_UTF8_MAXFNLEN) && wbuf[0])
+      {
+        int rv=WideCharToMultiByte(CP_UTF8,0,wbuf,-1,lpszLongPath,cchBuffer,NULL,NULL);
+        if (rv)
+        {
+          MBTOWIDE_FREE(sbuf);
+          return rv;
+        }
+      }
+      MBTOWIDE_FREE(sbuf);
+    }
+  }
+  return GetLongPathNameA(lpszShortPath, lpszLongPath, cchBuffer);
+}
+
+UINT GetTempFileNameUTF8(LPCTSTR lpPathName, LPCTSTR lpPrefixString, UINT uUnique, LPSTR lpTempFileName)
+{
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpPathName || !lpPrefixString || !lpTempFileName)) return 0;
+#endif
+  if (lpPathName && lpPrefixString && lpTempFileName AND_IS_NOT_WIN9X
+      && (WDL_HasUTF8(lpPathName) || WDL_HasUTF8(lpPrefixString)))
+  {
+    MBTOWIDE(sbuf1,lpPathName);
+    if (sbuf1_ok)
+    {
+      MBTOWIDE(sbuf2,lpPrefixString);
+      if (sbuf2_ok)
+      {
+        int rv;
+        WCHAR wbuf[WDL_UTF8_MAXFNLEN];
+        wbuf[0]=0;
+        rv=GetTempFileNameW(sbuf1,sbuf2,uUnique,wbuf);
+        WideCharToMultiByte(CP_UTF8,0,wbuf,-1,lpTempFileName,MAX_PATH,NULL,NULL);
+        MBTOWIDE_FREE(sbuf1);
+        MBTOWIDE_FREE(sbuf2);
+        return rv;
+      }
+      MBTOWIDE_FREE(sbuf1);
+    }
+  }
+  return GetTempFileNameA(lpPathName, lpPrefixString, uUnique, lpTempFileName);
+}
+
+DWORD GetTempPathUTF8(DWORD nBufferLength, LPTSTR lpBuffer)
+{
+  if (lpBuffer && nBufferLength > 1 AND_IS_NOT_WIN9X)
+  {
+
+    WCHAR wbuf[WDL_UTF8_MAXFNLEN];
+    wbuf[0]=0;
+    if (GetTempPathW(WDL_UTF8_MAXFNLEN,wbuf) && wbuf[0])
+    {
+      int rv=WideCharToMultiByte(CP_UTF8,0,wbuf,-1,lpBuffer,nBufferLength,NULL,NULL);
+      if (rv) return rv;
+    }
+  }
+  return GetTempPathA(nBufferLength,lpBuffer);
+}
 
 DWORD GetCurrentDirectoryUTF8(DWORD nBufferLength, LPTSTR lpBuffer)
 {
@@ -686,7 +799,7 @@ HANDLE CreateFileUTF8(LPCTSTR lpFileName,DWORD dwDesiredAccess,DWORD dwShareMode
     if (wstr_ok) h = CreateFileW(wstr,dwDesiredAccess,dwShareMode,lpSecurityAttributes,dwCreationDisposition,dwFlagsAndAttributes,hTemplateFile);
     MBTOWIDE_FREE(wstr);
 
-    if (h != INVALID_HANDLE_VALUE) return h;
+    if (h != INVALID_HANDLE_VALUE || (wstr_ok && (dwDesiredAccess & GENERIC_WRITE))) return h;
   }
   return CreateFileA(lpFileName,dwDesiredAccess,dwShareMode,lpSecurityAttributes,dwCreationDisposition,dwFlagsAndAttributes,hTemplateFile);
 }
@@ -694,6 +807,8 @@ HANDLE CreateFileUTF8(LPCTSTR lpFileName,DWORD dwDesiredAccess,DWORD dwShareMode
 
 int DrawTextUTF8(HDC hdc, LPCTSTR str, int nc, LPRECT lpRect, UINT format)
 {
+  WDL_ASSERT((format & DT_SINGLELINE) || !(format & (DT_BOTTOM|DT_VCENTER))); // if DT_BOTTOM or DT_VCENTER used, must have DT_SINGLELINE
+
   if (WDL_HasUTF8(str) AND_IS_NOT_WIN9X)
   {
     if (nc<0) nc=(int)strlen(str);
@@ -820,6 +935,7 @@ FILE *fopenUTF8(const char *filename, const char *mode)
     if (wbuf_ok) wdl_utf8_correctlongpath(wbuf);
     if (wbuf_ok)
     {
+      const char *p = mode;
       FILE *rv;
       WCHAR tb[32];      
       tb[0]=0;
@@ -827,6 +943,12 @@ FILE *fopenUTF8(const char *filename, const char *mode)
       rv=tb[0] ? _wfopen(wbuf,tb) : NULL;
       MBTOWIDE_FREE(wbuf);
       if (rv) return rv;
+
+      while (*p)
+      {
+        if (*p == '+' || *p == 'a' || *p == 'w') return NULL;
+        p++;
+      }
     }
   }
 #ifdef fopen
@@ -931,6 +1053,9 @@ HINSTANCE ShellExecuteUTF8(HWND hwnd, LPCTSTR lpOp, LPCTSTR lpFile, LPCTSTR lpPa
 
 BOOL GetUserNameUTF8(LPTSTR lpString, LPDWORD nMaxCount)
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpString||!nMaxCount)) return FALSE;
+#endif
   if (IS_NOT_WIN9X_AND lpString && nMaxCount)
   {
     WIDETOMB_ALLOC(wtmp,*nMaxCount);
@@ -957,6 +1082,9 @@ BOOL GetUserNameUTF8(LPTSTR lpString, LPDWORD nMaxCount)
 
 BOOL GetComputerNameUTF8(LPTSTR lpString, LPDWORD nMaxCount)
 {
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!lpString||!nMaxCount)) return 0;
+#endif
   if (IS_NOT_WIN9X_AND lpString && nMaxCount)
   {
     WIDETOMB_ALLOC(wtmp,*nMaxCount);
@@ -990,26 +1118,33 @@ BOOL GetComputerNameUTF8(LPTSTR lpString, LPDWORD nMaxCount)
 
 // these only bother using Wide versions if the filename has wide chars
 // (for now)
-#define PROFILESTR_COMMON \
+#define PROFILESTR_COMMON_BEGIN(ret_type) \
   if (IS_NOT_WIN9X_AND fnStr && WDL_HasUTF8(fnStr)) \
   { \
+    BOOL do_rv = 0; \
+    ret_type rv = 0; \
     MBTOWIDE(wfn,fnStr); \
     MBTOWIDE_NULLOK(wapp,appStr); \
     MBTOWIDE_NULLOK(wkey,keyStr); \
     if (wfn_ok && wapp_ok && wkey_ok) {
 
-#define PROFILESTR_COMMON_END \
+#define PROFILESTR_COMMON_END } /* wfn_ok etc */ \
     MBTOWIDE_FREE(wfn); \
     MBTOWIDE_FREE(wapp); \
     MBTOWIDE_FREE(wkey); \
-    return rv; \
-    } }
+    if (do_rv) return rv; \
+  } /* if has utf8 etc */ \
 
 UINT GetPrivateProfileIntUTF8(LPCTSTR appStr, LPCTSTR keyStr, INT def, LPCTSTR fnStr)
 {
-  PROFILESTR_COMMON
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!fnStr || !keyStr || !appStr)) return 0;
+#endif
 
-  const UINT rv = GetPrivateProfileIntW(wapp,wkey,def,wfn);
+  PROFILESTR_COMMON_BEGIN(UINT)
+
+  rv = GetPrivateProfileIntW(wapp,wkey,def,wfn);
+  do_rv = 1;
 
   PROFILESTR_COMMON_END
   return GetPrivateProfileIntA(appStr,keyStr,def,fnStr);
@@ -1017,27 +1152,31 @@ UINT GetPrivateProfileIntUTF8(LPCTSTR appStr, LPCTSTR keyStr, INT def, LPCTSTR f
 
 DWORD GetPrivateProfileStringUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPCTSTR defStr, LPTSTR retStr, DWORD nSize, LPCTSTR fnStr)
 {
-  PROFILESTR_COMMON
+  PROFILESTR_COMMON_BEGIN(DWORD)
   MBTOWIDE_NULLOK(wdef, defStr);
 
   WIDETOMB_ALLOC(buf, nSize);
 
-  DWORD rv = GetPrivateProfileStringW(wapp,wkey,wdef,buf,(DWORD) (buf_size / sizeof(WCHAR)),wfn);
-
-  const DWORD nullsz = (!wapp || !wkey) ? 2 : 1;
-  if (nSize<=nullsz)
+  if (wdef_ok && buf)
   {
-    memset(retStr,0,nSize);
-    rv=0;
-  }
-  else 
-  {
-    // rv does not include null character(s)
-    if (rv>0) rv = WideCharToMultiByte(CP_UTF8,0,buf,rv,retStr,nSize-nullsz,NULL,NULL);
-    if (rv > nSize-nullsz) rv=nSize-nullsz;
-    memset(retStr + rv,0,nullsz);
+    const DWORD nullsz = (!wapp || !wkey) ? 2 : 1;
+    rv = GetPrivateProfileStringW(wapp,wkey,wdef,buf,(DWORD) (buf_size / sizeof(WCHAR)),wfn);
+    if (nSize<=nullsz)
+    {
+      memset(retStr,0,nSize);
+      rv=0;
+    }
+    else
+    {
+      // rv does not include null character(s)
+      if (rv>0) rv = WideCharToMultiByte(CP_UTF8,0,buf,rv,retStr,nSize-nullsz,NULL,NULL);
+      if (rv > nSize-nullsz) rv=nSize-nullsz;
+      memset(retStr + rv,0,nullsz);
+    }
+    do_rv = 1;
   }
   
+  MBTOWIDE_FREE(wdef);
   WIDETOMB_FREE(buf);
   PROFILESTR_COMMON_END
   return GetPrivateProfileStringA(appStr,keyStr,defStr,retStr,nSize,fnStr);
@@ -1045,11 +1184,13 @@ DWORD GetPrivateProfileStringUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPCTSTR defStr
 
 BOOL WritePrivateProfileStringUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPCTSTR str, LPCTSTR fnStr)
 {
-  PROFILESTR_COMMON
+  PROFILESTR_COMMON_BEGIN(BOOL)
   MBTOWIDE_NULLOK(wval, str);
-
-  const BOOL rv = WritePrivateProfileStringW(wapp,wkey,wval,wfn);
-
+  if (wval_ok)
+  {
+    rv = WritePrivateProfileStringW(wapp,wkey,wval,wfn);
+    do_rv = 1;
+  }
   MBTOWIDE_FREE(wval);
 
   PROFILESTR_COMMON_END
@@ -1058,9 +1199,13 @@ BOOL WritePrivateProfileStringUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPCTSTR str, 
 
 BOOL GetPrivateProfileStructUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPVOID pStruct, UINT uSize, LPCTSTR fnStr)
 {
-  PROFILESTR_COMMON
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!fnStr || !keyStr || !appStr)) return 0;
+#endif
+  PROFILESTR_COMMON_BEGIN(BOOL)
 
-  const BOOL rv = GetPrivateProfileStructW(wapp,wkey,pStruct,uSize,wfn);
+  rv = GetPrivateProfileStructW(wapp,wkey,pStruct,uSize,wfn);
+  do_rv = 1;
 
   PROFILESTR_COMMON_END
   return GetPrivateProfileStructA(appStr,keyStr,pStruct,uSize,fnStr);
@@ -1068,16 +1213,21 @@ BOOL GetPrivateProfileStructUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPVOID pStruct,
 
 BOOL WritePrivateProfileStructUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPVOID pStruct, UINT uSize, LPCTSTR fnStr)
 {
-  PROFILESTR_COMMON
+#ifdef _DEBUG
+  if (WDL_NOT_NORMALLY(!fnStr || !keyStr || !appStr)) return 0;
+#endif
 
-  const BOOL rv = WritePrivateProfileStructW(wapp,wkey,pStruct,uSize,wfn);
+  PROFILESTR_COMMON_BEGIN(BOOL)
+
+  rv = WritePrivateProfileStructW(wapp,wkey,pStruct,uSize,wfn);
+  do_rv = 1;
 
   PROFILESTR_COMMON_END
   return WritePrivateProfileStructA(appStr,keyStr,pStruct,uSize,fnStr);
 }
 
 
-#undef PROFILESTR_COMMON
+#undef PROFILESTR_COMMON_BEGIN
 #undef PROFILESTR_COMMON_END
 
 
@@ -1156,7 +1306,12 @@ static LRESULT WINAPI cb_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPar
     RemoveProp(hwnd,WDL_UTF8_OLDPROCPROP);
     RemoveProp(hwnd,WDL_UTF8_OLDPROCPROP "W");
   }
-  else if (msg == CB_ADDSTRING || msg == CB_INSERTSTRING || msg == LB_ADDSTRING || msg == LB_INSERTSTRING)
+  else if (msg == CB_ADDSTRING ||
+           msg == CB_INSERTSTRING ||
+           msg == CB_FINDSTRINGEXACT ||
+           msg == CB_FINDSTRING ||
+           msg == LB_ADDSTRING ||
+           msg == LB_INSERTSTRING)
   {
     char *str=(char*)lParam;
     if (lParam && WDL_HasUTF8(str))
@@ -1204,8 +1359,67 @@ static LRESULT WINAPI cb_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPar
 
   return CallWindowProc(oldproc,hwnd,msg,wParam,lParam);
 }
+static int compareUTF8ToFilteredASCII(const char *utf, const char *ascii)
+{
+  for (;;)
+  {
+    unsigned char c1 = (unsigned char)*ascii++;
+    int c2;
+    if (!*utf || !c1) return *utf || c1;
+    utf += wdl_utf8_parsechar(utf, &c2);
+    if (c1 != c2)
+    {
+      if (c2 < 128) return 1; // if not UTF-8 character, strings differ
+      if (c1 != '?') return 1; // if UTF-8 and ASCII is not ?, strings differ
+    }
+  }
+}
 
-void WDL_UTF8_HookComboBox(HWND h)
+static LRESULT WINAPI cbedit_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+  WNDPROC oldproc = (WNDPROC)GetProp(hwnd,WDL_UTF8_OLDPROCPROP);
+  if (!oldproc) return 0;
+
+  if (msg==WM_NCDESTROY)
+  {
+    SetWindowLongPtr(hwnd, GWLP_WNDPROC,(INT_PTR)oldproc);
+    RemoveProp(hwnd,WDL_UTF8_OLDPROCPROP);
+    RemoveProp(hwnd,WDL_UTF8_OLDPROCPROP "W");
+  }
+  else if (msg == WM_SETTEXT && lParam && *(const char *)lParam)
+  {
+    WNDPROC oldproc2 = (WNDPROC)GetProp(hwnd,WDL_UTF8_OLDPROCPROP "W");
+    HWND par = GetParent(hwnd);
+
+    int sel = (int) SendMessage(par,CB_GETCURSEL,0,0);
+    if (sel>=0)
+    {
+      const int len = (int) SendMessage(par,CB_GETLBTEXTLEN,sel,0);
+      char tmp[1024], *p = (len+1) <= sizeof(tmp) ? tmp : (char*)calloc(len+1,1);
+      if (p)
+      {
+        SendMessage(par,CB_GETLBTEXT,sel,(LPARAM)p);
+        if (WDL_DetectUTF8(p)>0 && !compareUTF8ToFilteredASCII(p,(const char *)lParam))
+        {
+          MBTOWIDE(wbuf,p);
+          if (wbuf_ok)
+          {
+            LRESULT ret = CallWindowProcW(oldproc2 ? oldproc2 : oldproc,hwnd,msg,wParam,(LPARAM)wbuf);
+            MBTOWIDE_FREE(wbuf);
+            if (p != tmp) free(p);
+            return ret;
+          }
+          MBTOWIDE_FREE(wbuf);
+        }
+        if (p != tmp) free(p);
+      }
+    }
+  }
+
+  return CallWindowProc(oldproc,hwnd,msg,wParam,lParam);
+}
+
+void WDL_UTF8_HookListBox(HWND h)
 {
   if (!h||
     #ifdef WDL_SUPPORT_WIN9X
@@ -1214,13 +1428,22 @@ void WDL_UTF8_HookComboBox(HWND h)
     GetProp(h,WDL_UTF8_OLDPROCPROP)) return;
   SetProp(h,WDL_UTF8_OLDPROCPROP "W",(HANDLE)GetWindowLongPtrW(h,GWLP_WNDPROC));
   SetProp(h,WDL_UTF8_OLDPROCPROP,(HANDLE)SetWindowLongPtr(h,GWLP_WNDPROC,(INT_PTR)cb_newProc));
-
-  if (!s_combobox_atom) s_combobox_atom = (ATOM)GetClassWord(h,GCW_ATOM);
 }
 
-void WDL_UTF8_HookListBox(HWND h)
+void WDL_UTF8_HookComboBox(HWND h)
 {
-  WDL_UTF8_HookComboBox(h);
+  WDL_UTF8_HookListBox(h);
+  if (h && !s_combobox_atom) s_combobox_atom = (ATOM)GetClassWord(h,GCW_ATOM);
+
+  if (h)
+  {
+    h = FindWindowEx(h,NULL,"Edit",NULL);
+    if (h && !GetProp(h,WDL_UTF8_OLDPROCPROP))
+    {
+      SetProp(h,WDL_UTF8_OLDPROCPROP "W",(HANDLE)GetWindowLongPtrW(h,GWLP_WNDPROC));
+      SetProp(h,WDL_UTF8_OLDPROCPROP,(HANDLE)SetWindowLongPtr(h,GWLP_WNDPROC,(INT_PTR)cbedit_newProc));
+    }
+  }
 }
 
 static LRESULT WINAPI tc_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
@@ -1321,6 +1544,11 @@ static LRESULT WINAPI tv_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPar
   return CallWindowProc(oldproc,hwnd,msg,wParam,lParam);
 }
 
+struct lv_tmpbuf_state {
+  WCHAR *buf;
+  int buf_sz;
+};
+
 static LRESULT WINAPI lv_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
   WNDPROC oldproc = (WNDPROC)GetProp(hwnd,WDL_UTF8_OLDPROCPROP);
@@ -1328,6 +1556,14 @@ static LRESULT WINAPI lv_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPar
 
   if (msg==WM_NCDESTROY)
   {
+    struct lv_tmpbuf_state *buf = (struct lv_tmpbuf_state *)GetProp(hwnd,WDL_UTF8_OLDPROCPROP "B");
+    if (buf)
+    {
+      free(buf->buf);
+      free(buf);
+    }
+    RemoveProp(hwnd,WDL_UTF8_OLDPROCPROP "B");
+
     SetWindowLongPtr(hwnd, GWLP_WNDPROC,(INT_PTR)oldproc);
     RemoveProp(hwnd,WDL_UTF8_OLDPROCPROP);
   }
@@ -1354,7 +1590,11 @@ static LRESULT WINAPI lv_newProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPar
   {
     LPLVITEMA pItem = (LPLVITEMA) lParam;
     char *str;
-    if (pItem && (str=pItem->pszText) && (msg==LVM_SETITEMTEXTA || (pItem->mask&LVIF_TEXT)) && WDL_HasUTF8(str))
+    if (pItem &&
+        pItem->pszText != LPSTR_TEXTCALLBACK &&
+        (str=pItem->pszText) &&
+        (msg==LVM_SETITEMTEXTA || (pItem->mask&LVIF_TEXT)) &&
+        WDL_HasUTF8(str))
     {
       MBTOWIDE(wbuf,str);
       if (wbuf_ok)
@@ -1410,6 +1650,8 @@ void WDL_UTF8_HookListView(HWND h)
     #endif
     GetProp(h,WDL_UTF8_OLDPROCPROP)) return;
   SetProp(h,WDL_UTF8_OLDPROCPROP,(HANDLE)SetWindowLongPtr(h,GWLP_WNDPROC,(INT_PTR)lv_newProc));
+
+  SetProp(h,WDL_UTF8_OLDPROCPROP "B", (HANDLE)calloc(sizeof(struct lv_tmpbuf_state),1));
 }
 
 void WDL_UTF8_HookTreeView(HWND h)
@@ -1439,27 +1681,41 @@ void WDL_UTF8_ListViewConvertDispInfoToW(void *_di)
   NMLVDISPINFO *di = (NMLVDISPINFO *)_di;
   if (di && (di->item.mask & LVIF_TEXT) && di->item.pszText && di->item.cchTextMax>0)
   {
-    char tmp_buf[1024], *tmp=tmp_buf;
-    char *src = di->item.pszText;
+    static struct lv_tmpbuf_state s_buf;
+    const char *src = (const char *)di->item.pszText;
+    const size_t src_sz = strlen(src);
+    struct lv_tmpbuf_state *sb = (struct lv_tmpbuf_state *)GetProp(di->hdr.hwndFrom,WDL_UTF8_OLDPROCPROP "B");
+    if (WDL_NOT_NORMALLY(!sb)) sb = &s_buf; // if the caller forgot to call HookListView...
 
-    if (strlen(src) < 1024) strcpy(tmp,src);
-    else tmp = strdup(src);
-
-    if (!MultiByteToWideChar(CP_UTF8,MB_ERR_INVALID_CHARS,tmp,-1,(LPWSTR)di->item.pszText,di->item.cchTextMax))
+    if (!sb->buf || sb->buf_sz < src_sz)
     {
-      if (GetLastError()==ERROR_INSUFFICIENT_BUFFER)
+      const int newsz = (int) wdl_min(src_sz * 2 + 256, 0x7fffFFFF);
+      if (!sb->buf || sb->buf_sz < newsz)
       {
-        ((WCHAR *)di->item.pszText)[di->item.cchTextMax-1] = 0;
+        free(sb->buf);
+        sb->buf = (WCHAR *)malloc((sb->buf_sz = newsz) * sizeof(WCHAR));
+      }
+    }
+    if (WDL_NOT_NORMALLY(!sb->buf))
+    {
+      di->item.pszText = (char*)L"";
+      return;
+    }
+
+    di->item.pszText = (char*)sb->buf;
+
+    if (!MultiByteToWideChar(CP_UTF8,MB_ERR_INVALID_CHARS,src,-1,sb->buf,sb->buf_sz))
+    {
+      if (WDL_NOT_NORMALLY(GetLastError()==ERROR_INSUFFICIENT_BUFFER))
+      {
+        sb->buf[sb->buf_sz-1] = 0;
       }
       else
       {
-        if (!MultiByteToWideChar(CP_ACP,MB_ERR_INVALID_CHARS,tmp,-1,(LPWSTR)di->item.pszText,di->item.cchTextMax))
-          ((WCHAR *)di->item.pszText)[di->item.cchTextMax-1] = 0;
+        if (!MultiByteToWideChar(CP_ACP,MB_ERR_INVALID_CHARS,src,-1,sb->buf,sb->buf_sz))
+          sb->buf[sb->buf_sz-1] = 0;
       }
     }   
-
-    if (tmp!=tmp_buf) free(tmp);
-
   }
 }
 

--- a/thirdparty/WDL/source/WDL/win32_utf8.h
+++ b/thirdparty/WDL/source/WDL/win32_utf8.h
@@ -30,6 +30,7 @@ WDL_WIN32_UTF8_IMPL BOOL DeleteFileUTF8(LPCTSTR path);
 WDL_WIN32_UTF8_IMPL BOOL MoveFileUTF8(LPCTSTR existfn, LPCTSTR newfn);
 WDL_WIN32_UTF8_IMPL BOOL CopyFileUTF8(LPCTSTR existfn, LPCTSTR newfn, BOOL fie);
 WDL_WIN32_UTF8_IMPL DWORD GetCurrentDirectoryUTF8(DWORD nBufferLength, LPTSTR lpBuffer);
+WDL_WIN32_UTF8_IMPL DWORD GetTempPathUTF8(DWORD nBufferLength, LPTSTR lpBuffer);
 WDL_WIN32_UTF8_IMPL BOOL SetCurrentDirectoryUTF8(LPCTSTR path);
 WDL_WIN32_UTF8_IMPL BOOL RemoveDirectoryUTF8(LPCTSTR path);
 WDL_WIN32_UTF8_IMPL HINSTANCE LoadLibraryUTF8(LPCTSTR path);
@@ -90,6 +91,9 @@ WDL_WIN32_UTF8_IMPL BOOL GetPrivateProfileStructUTF8(LPCTSTR appStr, LPCTSTR key
 WDL_WIN32_UTF8_IMPL BOOL WritePrivateProfileStructUTF8(LPCTSTR appStr, LPCTSTR keyStr, LPVOID pStruct, UINT uSize, LPCTSTR fnStr);
 
 WDL_WIN32_UTF8_IMPL DWORD GetModuleFileNameUTF8(HMODULE hModule, LPTSTR fnStr, DWORD nSize);
+
+WDL_WIN32_UTF8_IMPL DWORD GetLongPathNameUTF8(LPCTSTR lpszShortPath, LPSTR lpszLongPath, DWORD cchBuffer);
+WDL_WIN32_UTF8_IMPL UINT GetTempFileNameUTF8(LPCTSTR lpPathName, LPCTSTR lpPrefixString, UINT uUnique, LPSTR lpTempFileName);
 
 WDL_WIN32_UTF8_IMPL BOOL CreateProcessUTF8( LPCTSTR lpApplicationName, LPTSTR lpCommandLine,
   LPSECURITY_ATTRIBUTES lpProcessAttributes,
@@ -181,6 +185,11 @@ WDL_WIN32_UTF8_IMPL BOOL CreateProcessUTF8( LPCTSTR lpApplicationName, LPTSTR lp
 #endif
 #define GetCurrentDirectory GetCurrentDirectoryUTF8
 
+#ifdef GetTempPath
+#undef GetTempPath
+#endif
+#define GetTempPath GetTempPathUTF8
+
 #ifdef SetCurrentDirectory
 #undef SetCurrentDirectory
 #endif
@@ -254,6 +263,16 @@ WDL_WIN32_UTF8_IMPL BOOL CreateProcessUTF8( LPCTSTR lpApplicationName, LPTSTR lp
 #undef GetModuleFileName
 #endif
 #define GetModuleFileName GetModuleFileNameUTF8
+
+#ifdef GetLongPathName
+#undef GetLongPathName
+#endif
+#define GetLongPathName GetLongPathNameUTF8
+
+#ifdef GetTempFileName
+#undef GetTempFileName
+#endif
+#define GetTempFileName GetTempFileNameUTF8
 
 #ifdef CreateProcess
 #undef CreateProcess


### PR DESCRIPTION
Changes introduced:
- Updated WDL/EEL2 to upstream `0a3e36e`.
- Add support for the JSFX preprocessor.
- Increased slider limit to 256.
- Added support for reading from RPLs with 256 sliders.
- Ensured slider lookup is case insensitive (like JSFX).
- Fixed bug where `file_avail` returned `0` despite there still being bytes remaining.
- Fixed bug regarding `file_open` which only allowed opening specific extensions.
- Add tests for all of the above.