### PR TITLE
ysfx: don't set gfx_clear to zero

### DIFF
--- a/sources/ysfx_api_gfx.cpp
+++ b/sources/ysfx_api_gfx.cpp
@@ -334,7 +334,6 @@ void ysfx_gfx_enter(ysfx_t *fx, bool doinit)
             // NOTE the above are according to eel_lice.h `resetVarsToStock`
             //   it helps to reset a few more, especially for clearing
             *fx->var.gfx_mode = 0;
-            *fx->var.gfx_clear = 0;
             *fx->var.gfx_texth = 0;
             *fx->var.mouse_cap = 0;
 


### PR DESCRIPTION
Forcing this variable to zero breaks several plugins that rely on the frame buffer not being cleared