### PR TITLE
api: add API for `strcpy_fromslider`

### DIFF
--- a/cmake.tests.txt
+++ b/cmake.tests.txt
@@ -79,6 +79,7 @@ add_executable(ysfx_tests
     "tests/ysfx_test_audio_flac.cpp"
     "tests/ysfx_test_filesystem.cpp"
     "tests/ysfx_test_preset.cpp"
+    "tests/ysfx_test_integration.cpp"
     "tests/ysfx_test_c_api.c"
     "tests/ysfx_test_utils.hpp"
     "tests/ysfx_test_utils.cpp"

--- a/cmake.ysfx.txt
+++ b/cmake.ysfx.txt
@@ -55,6 +55,8 @@ add_library(ysfx-private
         "sources/ysfx_api_gfx_lice.hpp"
         "sources/ysfx_eel_utils.cpp"
         "sources/ysfx_eel_utils.hpp"
+        "sources/ysfx_preprocess.cpp"
+        "sources/ysfx_preprocess.hpp"
         "sources/utility/sync_bitset.hpp"
         "sources/base64/Base64.hpp")
 target_compile_definitions(ysfx-private

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -185,6 +185,8 @@ YSFX_API bool ysfx_slider_is_enum(ysfx_t *fx, uint32_t index);
 YSFX_API uint32_t ysfx_slider_get_enum_names(ysfx_t *fx, uint32_t index, const char **dest, uint32_t destsize);
 // get a single label for the enumeration slider
 YSFX_API const char *ysfx_slider_get_enum_name(ysfx_t *fx, uint32_t slider_index, uint32_t enum_index);
+// get slider base path
+const char *ysfx_slider_path(ysfx_t *fx, uint32_t slider_index);
 // get whether the slider is a path (implies enumeration)
 YSFX_API bool ysfx_slider_is_path(ysfx_t *fx, uint32_t index);
 // get whether the slider is initially visible

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -802,6 +802,19 @@ const char *ysfx_slider_get_enum_name(ysfx_t *fx, uint32_t slider_index, uint32_
     return slider.enum_names[enum_index].c_str();
 }
 
+const char *ysfx_slider_path(ysfx_t *fx, uint32_t slider_index) {
+    ysfx_source_unit_t *main = fx->source.main.get();
+    if (slider_index >= ysfx_max_sliders || !main)
+        return 0;
+
+    ysfx_slider_t &slider = main->header.sliders[slider_index];
+    if (slider.path.empty()) {
+        return 0;
+    } else {
+        return slider.path.c_str();
+    }
+}
+
 bool ysfx_slider_is_path(ysfx_t *fx, uint32_t index)
 {
     ysfx_source_unit_t *main = fx->source.main.get();

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -22,6 +22,7 @@
 #include "ysfx_config.hpp"
 #include "ysfx_eel_utils.hpp"
 #include "ysfx_api_eel.hpp"
+#include "ysfx_preprocess.hpp"
 #include <type_traits>
 #include <algorithm>
 #include <functional>

--- a/sources/ysfx_api_eel.cpp
+++ b/sources/ysfx_api_eel.cpp
@@ -47,7 +47,6 @@ static ysfx::mutex atomic_mutex;
 #include "WDL/eel2/eel_fft.h"
 #include "WDL/eel2/eel_mdct.h"
 #include "WDL/eel2/eel_atomic.h"
-#include "WDL/eel2/eel_pproc.h"
 
 //------------------------------------------------------------------------------
 void ysfx_api_init_eel()
@@ -145,30 +144,4 @@ void NSEEL_HOSTSTUB_EnterMutex()
 
 void NSEEL_HOSTSTUB_LeaveMutex()
 {
-}
-
-bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str)
-{
-    std::string line;
-    uint32_t lineno = 0;
-
-    line.reserve(256);
-
-    WDL_FastString file_str, pp_str;
-    while (reader.read_next_line(line)) {
-        line += "\n";
-        const char *linep = line.c_str();
-        file_str.Append(linep);
-    }
-
-    EEL2_PreProcessor pproc;
-    const char *err = pproc.preprocess(file_str.Get(), &pp_str);
-    if (err) {
-        error->line = 0;
-        error->message = std::string("Invalid section: ") + err;
-        return false;
-    }
-
-    in_str.append(pp_str.Get(), pp_str.GetLength());
-    return true;
 }

--- a/sources/ysfx_api_eel.hpp
+++ b/sources/ysfx_api_eel.hpp
@@ -58,5 +58,3 @@ private:
 #define EEL_STRING_GET_FOR_INDEX(x, wr) (ysfx_string_access_unlocked((ysfx_t *)(opaque), x, wr, false))
 #define EEL_STRING_GET_FOR_WRITE(x, wr) (ysfx_string_access_unlocked((ysfx_t *)(opaque), x, wr, true))
 #define EEL_STRING_MUTEXLOCK_SCOPE ysfx_string_scoped_lock lock{(ysfx_t *)(opaque)};
-
-bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string &str);

--- a/sources/ysfx_preprocess.cpp
+++ b/sources/ysfx_preprocess.cpp
@@ -1,0 +1,53 @@
+// Copyright 2024 Joep Vanlier
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ysfx.hpp"
+#include "ysfx_utils.hpp"
+
+#include "WDL/ptrlist.h"
+#include "WDL/assocarray.h"
+#include "WDL/mutex.h"
+
+#include "WDL/wdlstring.h"
+#include "WDL/eel2/eel_pproc.h"
+
+
+bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str)
+{
+    std::string line;
+    uint32_t lineno = 0;
+
+    line.reserve(256);
+
+    WDL_FastString file_str, pp_str;
+    while (reader.read_next_line(line)) {
+        line += "\n";
+        const char *linep = line.c_str();
+        file_str.Append(linep);
+    }
+
+    EEL2_PreProcessor pproc;
+    const char *err = pproc.preprocess(file_str.Get(), &pp_str);
+    if (err) {
+        error->line = 0;
+        error->message = std::string("Invalid section: ") + err;
+        return false;
+    }
+
+    in_str.append(pp_str.Get(), pp_str.GetLength());
+    return true;
+}

--- a/sources/ysfx_preprocess.hpp
+++ b/sources/ysfx_preprocess.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include "ysfx.h"
+#include <string>
+
+bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str);

--- a/tests/ysfx_test_integration.cpp
+++ b/tests/ysfx_test_integration.cpp
@@ -1,0 +1,73 @@
+// Copyright 2024 Joep Vanlier
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ysfx.h"
+#include "ysfx_test_utils.hpp"
+#include "ysfx_api_eel.hpp"
+#include <catch.hpp>
+
+#include <iostream>
+
+TEST_CASE("integration", "[integration]")
+{
+    SECTION("strcpy_from_slider")
+    {
+        const char *text =
+            "desc:example" "\n"
+            "out_pin:output" "\n"
+            "slider43:/filedir:blip.txt:Directory test" "\n"
+            "@init" "\n"
+            "slider43 = 1;" "\n"
+            "x = 5;" "\n"
+            "strcpy_fromslider(x, slider43);" "\n"
+            "slider43 = 2;" "\n"
+            "x = 6;" "\n"
+            "strcpy_fromslider(x, slider43);" "\n"
+            "slider43 = 0;" "\n"
+            "x = 7;" "\n"
+            "strcpy_fromslider(x, slider43);" "\n"
+            "@sample" "\n"
+            "spl0=0.0;" "\n";
+
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
+        
+        scoped_new_dir dir_data("${root}/Data");
+        scoped_new_dir dir_data2("${root}/Data/filedir");
+        scoped_new_txt f1("${root}/Data/filedir/blip.txt", "blah");
+        scoped_new_txt f2("${root}/Data/filedir/blap.txt", "bloo");
+        scoped_new_txt f3("${root}/Data/filedir/blop.txt", "bloo");
+
+        ysfx_config_u config{ysfx_config_new()};
+        ysfx_set_data_root(config.get(), dir_data.m_path.c_str());
+        ysfx_u fx{ysfx_new(config.get())};
+
+        REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+        REQUIRE(ysfx_compile(fx.get(), 0));
+        ysfx_init(fx.get());
+
+        std::string txt;
+        ysfx_string_get(fx.get(), 5, txt);
+        REQUIRE((txt == "filedir/blip.txt"));
+
+        ysfx_string_get(fx.get(), 6, txt);
+        REQUIRE((txt == "filedir/blop.txt"));
+
+        ysfx_string_get(fx.get(), 7, txt);
+        REQUIRE((txt == "filedir/blap.txt"));
+    };
+}

--- a/tests/ysfx_test_parse.cpp
+++ b/tests/ysfx_test_parse.cpp
@@ -19,6 +19,7 @@
 //
 
 #include "ysfx.hpp"
+#include "ysfx_preprocess.hpp"
 #include "ysfx_parse.hpp"
 #include "ysfx_test_utils.hpp"
 #include <catch.hpp>

--- a/tests/ysfx_test_serialization.cpp
+++ b/tests/ysfx_test_serialization.cpp
@@ -169,5 +169,5 @@ TEST_CASE("save and load", "[serialization]")
         REQUIRE(ysfx::unpack_f32le(&state->data[2 * sizeof(float)]) == 200);
         REQUIRE(ysfx::unpack_f32le(&state->data[3 * sizeof(float)]) == 300);
         REQUIRE(ysfx::unpack_f32le(&state->data[4 * sizeof(float)]) == 400);
-    };    
+    };
 }


### PR DESCRIPTION
**Why this PR?**
The API endpoint `strcpy_fromslider` was missing. Some plugins need this.

Note that some additional work is still left to be done to get the folder traversal correct for populating these sliders (right now it doesn't seem to recurse).

I also moved the preprocessor into its own file. I feel adding it to the API file was a mistake in retrospect.