### PR TITLE
plugin: fix incorrect latency presented by plugin

### DIFF
--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -518,7 +518,7 @@ void YsfxProcessor::Impl::processLatency()
 
     // NOTE: ignore pdc_bot_ch and pdc_top_ch
 
-    int samples = juce::roundToInt(latency * m_self->getSampleRate());
+    int samples = juce::roundToInt(latency);
     m_self->setLatencySamples(samples);
 }
 


### PR DESCRIPTION
Latency as set in ysfx is already in samples. Multiplying it by the sampling rate results in incorrect latencies. Note that there is no support for `pdc_bot_ch` and `pdc_top_ch` yet (even after this PR).