### PR TITLE
graphics_view: also clear semaphor on fx reset

### DIFF
--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -717,6 +717,8 @@ void YsfxGraphicsView::Impl::BackgroundWork::stop()
     std::lock_guard<std::mutex> lock{m_messagesMutex};
     while (!m_messages.empty())
         m_messages.pop();
+
+    m_sema.clear();
 }
 
 void YsfxGraphicsView::Impl::BackgroundWork::postMessage(std::shared_ptr<Message> message)
@@ -737,10 +739,12 @@ void YsfxGraphicsView::Impl::BackgroundWork::run()
         std::shared_ptr<Message> msg = popNextMessage();
         jassert(msg);
 
-        switch (msg->m_type) {
-        case '@gfx':
-            processGfxMessage(static_cast<GfxMessage &>(*msg));
-            break;
+        if (msg) {
+            switch (msg->m_type) {
+            case '@gfx':
+                processGfxMessage(static_cast<GfxMessage &>(*msg));
+                break;
+            }
         }
     }
 }

--- a/plugin/utility/rt_semaphore.h
+++ b/plugin/utility/rt_semaphore.h
@@ -39,11 +39,13 @@ public:
 
     void post();
     void wait();
+    void clear();
     bool try_wait();
     bool timed_wait(uint32_t milliseconds);
 
     void post(std::error_code& ec) noexcept;
     void wait(std::error_code& ec) noexcept;
+    void clear(std::error_code& ec) noexcept;
     bool try_wait(std::error_code& ec) noexcept;
     bool timed_wait(uint32_t milliseconds, std::error_code& ec) noexcept;
 


### PR DESCRIPTION
**Why this PR?**
It's rare, but on gfx heavy plugins, it can happen that there is still a message left on the render queue for the background thread (if you switch FX fast enough). When that happens, the message gets cleared, but the semaphor list does not. This results in the semaphor triggering with an empty message queue, which in turn leads to a null pointer dereference.

This PR clears the semaphor by depleting the queue at the same time as the messages being deleted.