### PR TITLE
gfx: reduce overdraw

### DIFF
--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -203,6 +203,8 @@ YsfxGraphicsView::YsfxGraphicsView()
     m_impl->m_asyncMouseCursor->addListener(m_impl.get());
     m_impl->m_asyncShowMenu->addListener(m_impl.get());
 
+    setOpaque(true);
+
     setWantsKeyboardFocus(true);
 }
 
@@ -281,6 +283,7 @@ void YsfxGraphicsView::paint(juce::Graphics &g)
     m_pixelFactor = juce::jmax(1.0f, g.getInternalContext().getPhysicalPixelScaleFactor());
 
     ///
+    g.setImageResamplingQuality(juce::Graphics::lowResamplingQuality);
     std::lock_guard<std::mutex> lock{m_impl->m_asyncRepainter->m_mutex};
     juce::Image &image = m_impl->m_asyncRepainter->m_bitmap;
 
@@ -293,8 +296,8 @@ void YsfxGraphicsView::paint(juce::Graphics &g)
         g.drawImageAt(image, off.x, off.y);
     }
     else {
-        juce::Rectangle<int> dest{off.x, off.y, target->m_gfxWidth, target->m_gfxHeight};
-        g.drawImage(image, dest.toFloat() / m_pixelFactor);
+        g.setOpacity(1.0f);
+        g.drawImageTransformed(image, juce::AffineTransform::translation(0.0f, 0.0f).scaled(1.0f / m_pixelFactor), false);
     }
 }
 

--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -822,12 +822,19 @@ void YsfxGraphicsView::Impl::BackgroundWork::processGfxMessage(GfxMessage &msg)
         juce::Image::BitmapData src{imgsrc, juce::Image::BitmapData::readOnly};
         juce::Image::BitmapData dst{imgdst, juce::Image::BitmapData::writeOnly};
 
-        if (src.lineStride == dst.lineStride) {
-            memcpy(dst.data, src.data, (size_t)(h * src.lineStride));
-        }
-        else {
-            for (int row = 0; row < h; ++row)
-                memcpy(dst.getLinePointer(row), src.getLinePointer(row), (size_t)(w * src.pixelStride));
+        // Set alpha channel to 255 explicitly.
+        for (int row = 0; row < h; ++row)
+        {
+            juce::uint8* from = src.getLinePointer(row);
+            juce::uint8* to = dst.getLinePointer(row);
+            for (int pix = 0; pix < w; ++pix)
+            {
+                juce::uint32 pixel = *reinterpret_cast<const juce::uint32*>(from);
+                *reinterpret_cast<juce::uint32*>(to) = pixel | 0xFF000000;
+
+                from += src.pixelStride;
+                to += src.pixelStride;
+            }
         }
 
         msg.m_asyncRepainter->m_hasBitmapChanged = true;

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -38,6 +38,7 @@ struct YsfxEditor::Impl {
     std::unique_ptr<juce::PopupMenu> m_presetsPopup;
     bool m_fileChooserActive = false;
     bool m_mustResizeToGfx = true;
+    bool m_justResized = true;
 
     //==========================================================================
     void updateInfo();
@@ -100,6 +101,7 @@ YsfxEditor::YsfxEditor(YsfxProcessor &proc)
     setLookAndFeel(&lnf);
     juce::LookAndFeel::setDefaultLookAndFeel(&lnf);
 
+    setOpaque(true);
     setSize(defaultEditorWidth, defaultEditorHeight);
     setResizable(true, true);
     m_impl->createUI();
@@ -107,6 +109,20 @@ YsfxEditor::YsfxEditor(YsfxProcessor &proc)
     m_impl->relayoutUILater();
 
     m_impl->updateInfo();
+}
+
+void YsfxEditor::paint (juce::Graphics& g)
+{
+    if (m_impl && m_impl->m_justResized) {
+        g.fillAll(juce::Colours::black);
+        m_impl->m_justResized = false;
+    } else {
+        // Redraw only the top.
+        const juce::Rectangle<int> bounds = getLocalBounds();
+        g.setColour(juce::Colours::black);
+        g.setOpacity(1.0f);
+        g.fillRect(juce::Rectangle<int>(0, 0, bounds.getWidth(), 70));
+    }
 }
 
 YsfxEditor::~YsfxEditor()
@@ -442,6 +458,7 @@ void YsfxEditor::Impl::relayoutUI()
     }
 
     m_centerViewPort->setViewedComponent(viewed, false);
+    m_justResized = true;
 
     if (m_relayoutTimer)
         m_relayoutTimer->stopTimer();

--- a/plugin/editor.h
+++ b/plugin/editor.h
@@ -27,6 +27,7 @@ public:
 
 protected:
     void resized() override;
+    void paint (juce::Graphics& g) override;
 
 private:
     struct Impl;


### PR DESCRIPTION
**Why this PR?**
The current version overdraws a lot. By setting things as non opaque and rendering those things that need to, we can reduce this overdraw.