### PR TITLE
editor: serialize some preferences

### DIFF
--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -256,29 +256,17 @@ void YsfxGraphicsView::setEffect(ysfx_t *fx)
     setMouseCursor(juce::MouseCursor{juce::MouseCursor::NormalCursor});
 }
 
-void YsfxGraphicsView::toggleScaling()
+void YsfxGraphicsView::setScaling(float new_scaling)
 {
-    if (m_outputScalingFactor > 1.6f) {
-        m_outputScalingFactor = 1.0f;
-    } else if (m_outputScalingFactor > 1.4f) {
-        m_outputScalingFactor = 2.0f;
-    } else {
-        m_outputScalingFactor = 1.5f;
-    }
-}
-
-std::string YsfxGraphicsView::getScalingString()
-{
-    if (m_outputScalingFactor > 1.6f) {
-        return std::string("x2");
-    } else if (m_outputScalingFactor > 1.4f) {
-        return std::string("x1.5");
-    } else {
-        return std::string("x1");
-    }
+    m_outputScalingFactor = new_scaling;
 }
 
 float YsfxGraphicsView::getScaling()
+{
+    return m_outputScalingFactor;
+}
+
+float YsfxGraphicsView::getTotalScaling()
 {
     // We rescale this only when we have active UI rescaling on under the assumption that that mode
     // is used mostly for JSFX that do not have the inherent ability to scale with the UI.
@@ -558,8 +546,8 @@ bool YsfxGraphicsView::Impl::updateGfxTarget(int newWidth, int newHeight, int ne
 
     // newWidth is set when the JSFX initializes
     float scaling_factor = 1.0f / (output_scaling > 1.1f ? pixel_factor : 1.0f);
-    newWidth = (newWidth == -1) ? m_self->getWidth() : newWidth * scaling_factor;
-    newHeight = (newHeight == -1) ? m_self->getHeight() : newHeight * scaling_factor;
+    newWidth = (newWidth == -1) ? m_self->getWidth() : (int) newWidth * scaling_factor;
+    newHeight = (newHeight == -1) ? m_self->getHeight() : (int) newHeight * scaling_factor;
     newRetina = (newRetina == -1) ? target->m_wantRetina : newRetina;
 
     // Set internal JSFX texture size

--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -292,7 +292,6 @@ void YsfxGraphicsView::paint(juce::Graphics &g)
     }
 
     ///
-    juce::Point<int> off = m_impl->getDisplayOffset();
     Impl::GfxTarget *target = m_impl->m_gfxTarget.get();
 
     // Get final pixel size (we want to correct for any DPI scaling that's happening by making the

--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -546,8 +546,8 @@ bool YsfxGraphicsView::Impl::updateGfxTarget(int newWidth, int newHeight, int ne
 
     // newWidth is set when the JSFX initializes
     float scaling_factor = 1.0f / (output_scaling > 1.1f ? pixel_factor : 1.0f);
-    newWidth = (newWidth == -1) ? m_self->getWidth() : (int) newWidth * scaling_factor;
-    newHeight = (newHeight == -1) ? m_self->getHeight() : (int) newHeight * scaling_factor;
+    newWidth = (newWidth == -1) ? m_self->getWidth() : (int) (newWidth * scaling_factor);
+    newHeight = (newHeight == -1) ? m_self->getHeight() : (int) (newHeight * scaling_factor);
     newRetina = (newRetina == -1) ? target->m_wantRetina : newRetina;
 
     // Set internal JSFX texture size

--- a/plugin/components/graphics_view.h
+++ b/plugin/components/graphics_view.h
@@ -47,7 +47,6 @@ protected:
 private:
     float m_pixelFactor{1.0f};
     float m_outputScalingFactor{1.0f};
-    bool m_clearPaint{true};
 
     struct Impl;
     std::unique_ptr<Impl> m_impl;

--- a/plugin/components/graphics_view.h
+++ b/plugin/components/graphics_view.h
@@ -25,9 +25,9 @@ public:
     YsfxGraphicsView();
     ~YsfxGraphicsView() override;
     void setEffect(ysfx_t *fx);
-    void toggleScaling();
+    void setScaling(float new_scaling);
     float getScaling();
-    std::string getScalingString();
+    float getTotalScaling();
 
 protected:
     void paint(juce::Graphics &g) override;

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -216,7 +216,7 @@ void YsfxProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
 
     ysfx_t *fx = m_impl->m_fx.get();
     m_impl->m_sample_rate = sampleRate;
-    m_impl->m_block_size = samplesPerBlock;
+    m_impl->m_block_size = static_cast<uint32_t>(samplesPerBlock);
 
     ysfx_set_sample_rate(fx, sampleRate);
     ysfx_set_block_size(fx, (uint32_t)samplesPerBlock);

--- a/sources/ysfx_preprocess.cpp
+++ b/sources/ysfx_preprocess.cpp
@@ -29,8 +29,6 @@
 bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str)
 {
     std::string line;
-    uint32_t lineno = 0;
-
     line.reserve(256);
 
     WDL_FastString file_str, pp_str;


### PR DESCRIPTION
Fixes in this PR
- Simplify the scaling logic
- Store the size used last for each plugin in global config file
- Store last folder where we opened a JSFX and use that as initial folder to start browsing