### PR TITLE
api: fix `strcpy_from_slider` on regular sliders

### DIFF
--- a/sources/ysfx_api_reaper.cpp
+++ b/sources/ysfx_api_reaper.cpp
@@ -434,10 +434,17 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_strcpy_from_slider(void *opaque, EEL_F *st
     }
 
     uint32_t enum_idx = static_cast<uint32_t>(ysfx_slider_get_value(fx, slider_idx));
-    std::string root{ysfx_slider_path(fx, slider_idx)};
-    root.erase(0, 1);
+    
+    const char* path = ysfx_slider_path(fx, slider_idx);
     std::string name{ysfx_slider_get_enum_name(fx, slider_idx, enum_idx)};
-    std::string full_name = root + "/" + name;
+    std::string full_name;
+    if (path) {
+        std::string root{path};
+        root.erase(0, 1);
+        full_name = root + "/" + name;
+    } else {
+        full_name = name;
+    };
 
     auto process_str = [](void *userdata, WDL_FastString &str) {
         std::string *value = (std::string *)userdata;
@@ -447,9 +454,8 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_strcpy_from_slider(void *opaque, EEL_F *st
     if (!ysfx_string_access(fx, *str_, true, +process_str, &full_name))
         return 0;
     
-    return 1;
+    return *str_;
 }
-
 
 //------------------------------------------------------------------------------
 void ysfx_api_init_reaper()

--- a/tests/ysfx_test_integration.cpp
+++ b/tests/ysfx_test_integration.cpp
@@ -70,4 +70,43 @@ TEST_CASE("integration", "[integration]")
         ysfx_string_get(fx.get(), 7, txt);
         REQUIRE((txt == "filedir/blap.txt"));
     };
+
+    SECTION("strcpy_from_slider_non_file")
+    {
+        const char *text =
+            "desc:test" "\n"
+            "out_pin:output" "\n"
+            "slider43: 0<0,1,1{L + R,L || R}>Summed Mode" "\n"
+            "slider44: 1<0,1,1{A,F}>Summed Mode" "\n"
+            "@init" "\n"
+            "x = 5;"
+            "strcpy_fromslider(x, slider43);" "\n"
+            "x = 6;" "\n"
+            "slider43 = 1;" "\n"
+            "strcpy_fromslider(x, slider43);" "\n"
+            "x = 7;" "\n"
+            "strcpy_fromslider(x, slider44);" "\n"
+            "@sample" "\n"
+            "spl0=0.0;" "\n";
+
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
+        
+        ysfx_config_u config{ysfx_config_new()};
+        ysfx_u fx{ysfx_new(config.get())};
+
+        REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+        REQUIRE(ysfx_compile(fx.get(), 0));
+        ysfx_init(fx.get());
+
+        std::string txt;
+        ysfx_string_get(fx.get(), 5, txt);
+        REQUIRE((txt == "L + R"));
+
+        ysfx_string_get(fx.get(), 6, txt);
+        REQUIRE((txt == "L || R"));
+
+        ysfx_string_get(fx.get(), 7, txt);
+        REQUIRE((txt == "F"));
+    };
 }


### PR DESCRIPTION
I missed part of the API description here leading to potential crash bugs.