### PR TITLE
ide: manually enable variable watches

### DIFF
--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -393,6 +393,7 @@ void YsfxEditor::Impl::openCodeEditor()
 {
     m_codeWindow->setVisible(true);
     m_codeWindow->toFront(true);
+    m_ideView->focusOnCodeEditor();
 }
 
 juce::RecentlyOpenedFilesList YsfxEditor::Impl::loadRecentFiles()


### PR DESCRIPTION
**Why this PR?**
Watching all variables in a JSFX on a timer ruins performance by hogging the message thread. We should only do this when requested explicitly. We should also not do this when the editor is not open.