### PR TITLE
Automate latch

### DIFF
--- a/exports/ysfx.txt
+++ b/exports/ysfx.txt
@@ -58,6 +58,7 @@ ysfx_receive_midi_from_bus
 ysfx_send_trigger
 ysfx_fetch_slider_changes
 ysfx_fetch_slider_automations
+ysfx_fetch_slider_touches
 ysfx_get_slider_visibility
 ysfx_process_float
 ysfx_process_double

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -280,7 +280,7 @@ YSFX_API bool ysfx_send_trigger(ysfx_t *fx, uint32_t index);
 YSFX_API uint64_t ysfx_fetch_slider_changes(ysfx_t *fx);
 // get a bit mask of sliders whose values must be automated, and clear it to zero
 YSFX_API uint64_t ysfx_fetch_slider_automations(ysfx_t *fx);
-// get a bit mask of sliders whose values are currently being touched (it does _not_ get cleared)
+// get a bit mask of sliders whose values are currently being touched
 YSFX_API uint64_t ysfx_fetch_slider_touches(ysfx_t *fx);
 // get a bit mask of sliders currently visible
 YSFX_API uint64_t ysfx_get_slider_visibility(ysfx_t *fx);

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -280,6 +280,8 @@ YSFX_API bool ysfx_send_trigger(ysfx_t *fx, uint32_t index);
 YSFX_API uint64_t ysfx_fetch_slider_changes(ysfx_t *fx);
 // get a bit mask of sliders whose values must be automated, and clear it to zero
 YSFX_API uint64_t ysfx_fetch_slider_automations(ysfx_t *fx);
+// get a bit mask of sliders whose values are currently being touched (it does _not_ get cleared)
+YSFX_API uint64_t ysfx_fetch_slider_touches(ysfx_t *fx);
 // get a bit mask of sliders currently visible
 YSFX_API uint64_t ysfx_get_slider_visibility(ysfx_t *fx);
 

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -194,8 +194,8 @@ YSFX_API bool ysfx_slider_is_initially_visible(ysfx_t *fx, uint32_t index);
 
 // get the value of the slider
 YSFX_API ysfx_real ysfx_slider_get_value(ysfx_t *fx, uint32_t index);
-// set the value of the slider, and call @slider later if value has changed
-YSFX_API void ysfx_slider_set_value(ysfx_t *fx, uint32_t index, ysfx_real value);
+// set the value of the slider, and call @slider later if the value changed and we choose to notify the effect
+YSFX_API void ysfx_slider_set_value(ysfx_t *fx, uint32_t index, ysfx_real value, bool notify);
 
 typedef enum ysfx_compile_option_e {
     // skip compiling the @serialize section

--- a/plugin/parameter.cpp
+++ b/plugin/parameter.cpp
@@ -99,11 +99,26 @@ float YsfxParameter::getValue() const
 void YsfxParameter::setValue(float newValue)
 {
     m_value = newValue;
+    m_hostUpdated = true;
+}
+
+void YsfxParameter::setValueNoNotify(float newValue)
+{
+    m_value = newValue;
 }
 
 float YsfxParameter::getDefaultValue() const
 {
     return 0.0f;
+}
+
+bool YsfxParameter::wasUpdatedByHost() {
+    if (m_hostUpdated) {
+        m_hostUpdated = false;
+        return true;
+    } else {
+        return false;
+    }
 }
 
 juce::String YsfxParameter::getText(float normalisedValue, int) const

--- a/plugin/parameter.h
+++ b/plugin/parameter.h
@@ -39,13 +39,16 @@ public:
     const juce::NormalisableRange<float> &getNormalisableRange() const override { return m_range; }
     float getValue() const override;
     void setValue(float newValue) override;
+    void setValueNoNotify(float newValue);
     float getDefaultValue() const override;
     juce::String getText(float normalisedValue, int) const override;
     float getValueForText(const juce::String &text) const override;
+    bool wasUpdatedByHost();  // Fetches whether this was updated by host and resets it
 
 private:
     ysfx_u m_fx;
     int m_sliderIndex = 0;
     float m_value = 0.0f;
+    std::atomic<bool> m_hostUpdated{false};
     const juce::NormalisableRange<float> m_range{0.0f, 1.0f};
 };

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -242,8 +242,9 @@ void YsfxProcessor::Impl::processBlockGenerically(const void *inputs[], void *ou
     uint64_t sliderParametersChanged = m_sliderParametersChanged.exchange(0);
     if (sliderParametersChanged) {
         for (int i = 0; i < ysfx_max_sliders; ++i) {
-            if (sliderParametersChanged & ((uint64_t)1 << i))
+            if (sliderParametersChanged & ((uint64_t)1 << i)) {
                 syncParameterToSlider(i);
+            }
         }
     }
 
@@ -506,7 +507,7 @@ void YsfxProcessor::Impl::processSliderChanges()
             if (param->existsAsSlider()) {
                 float normValue = param->convertFromYsfxValue(ysfx_slider_get_value(fx, (uint32_t)i));
                 if (param->getValue() != normValue) {
-                    param->setValue(normValue);
+                    param->setValueNoNotify(normValue);  // This should not trigger @slider
                     changed |= uint64_t{1} << i;
                 }
             }
@@ -583,7 +584,8 @@ void YsfxProcessor::Impl::syncParameterToSlider(int index)
     YsfxParameter *param = m_self->getYsfxParameter(index);
     if (param->existsAsSlider()) {
         ysfx_real actualValue = param->convertToYsfxValue(param->getValue());
-        ysfx_slider_set_value(m_fx.get(), (uint32_t)index, actualValue);
+
+        ysfx_slider_set_value(m_fx.get(), (uint32_t)index, actualValue, param->wasUpdatedByHost());
     }
 }
 

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -986,6 +986,7 @@ void ysfx_first_init(ysfx_t *fx)
 
     fx->slider.automate_mask.store(0);
     fx->slider.change_mask.store(0);
+    fx->slider.touch_mask.store(0);
     ysfx_update_slider_visibility_mask(fx);
 }
 
@@ -1089,6 +1090,11 @@ uint64_t ysfx_fetch_slider_changes(ysfx_t *fx)
 uint64_t ysfx_fetch_slider_automations(ysfx_t *fx)
 {
     return fx->slider.automate_mask.exchange(0);
+}
+
+uint64_t ysfx_fetch_slider_touches(ysfx_t *fx)
+{
+    return fx->slider.touch_mask.load();
 }
 
 uint64_t ysfx_get_slider_visibility(ysfx_t *fx)

--- a/sources/ysfx.hpp
+++ b/sources/ysfx.hpp
@@ -57,6 +57,7 @@ struct ysfx_s {
     eel_string_context_state_u string_ctx;
     ysfx::mutex string_mutex;
     ysfx::mutex atomic_mutex;
+    ysfx::mutex image_mutex;
     NSEEL_VMCTX_u vm;
 
     // some default values, these are not standard, just arbitrary

--- a/sources/ysfx.hpp
+++ b/sources/ysfx.hpp
@@ -147,6 +147,7 @@ struct ysfx_s {
         ysfx::sync_bitset64 automate_mask;
         ysfx::sync_bitset64 change_mask;
         ysfx::sync_bitset64 visible_mask;
+        ysfx::sync_bitset64 touch_mask;
     } slider;
 
     // Triggers

--- a/sources/ysfx_api_eel.cpp
+++ b/sources/ysfx_api_eel.cpp
@@ -129,6 +129,16 @@ void ysfx_string_unlock(ysfx_t *fx)
     fx->string_mutex.unlock();
 }
 
+void ysfx_image_lock(ysfx_t *fx)
+{
+    fx->image_mutex.lock();
+}
+
+void ysfx_image_unlock(ysfx_t *fx)
+{
+    fx->image_mutex.unlock();
+}
+
 const char *ysfx_string_access_unlocked(ysfx_t *fx, ysfx_real id, WDL_FastString **fs, bool for_write)
 {
     return fx->string_ctx->GetStringForIndex(id, fs, for_write);

--- a/sources/ysfx_api_eel.hpp
+++ b/sources/ysfx_api_eel.hpp
@@ -45,6 +45,8 @@ bool ysfx_string_get(ysfx_t *fx, ysfx_real id, std::string &txt);
 bool ysfx_string_set(ysfx_t *fx, ysfx_real id, const std::string &txt);
 void ysfx_string_lock(ysfx_t *fx);
 void ysfx_string_unlock(ysfx_t *fx);
+void ysfx_image_lock(ysfx_t *fx);
+void ysfx_image_unlock(ysfx_t *fx);
 const char *ysfx_string_access_unlocked(ysfx_t *fx, ysfx_real id, WDL_FastString **fs, bool for_write);
 
 struct ysfx_string_scoped_lock {
@@ -54,7 +56,15 @@ private:
     ysfx_t *m_fx = nullptr;
 };
 
+struct ysfx_image_scoped_lock {
+    ysfx_image_scoped_lock(ysfx_t *fx) : m_fx(fx) { ysfx_image_lock(fx); }
+    ~ysfx_image_scoped_lock() { ysfx_image_unlock(m_fx); }
+private:
+    ysfx_t *m_fx = nullptr;
+};
+
 #define EEL_STRING_GET_CONTEXT_POINTER(opaque) (((ysfx_t *)(opaque))->string_ctx.get())
 #define EEL_STRING_GET_FOR_INDEX(x, wr) (ysfx_string_access_unlocked((ysfx_t *)(opaque), x, wr, false))
 #define EEL_STRING_GET_FOR_WRITE(x, wr) (ysfx_string_access_unlocked((ysfx_t *)(opaque), x, wr, true))
 #define EEL_STRING_MUTEXLOCK_SCOPE ysfx_string_scoped_lock lock{(ysfx_t *)(opaque)};
+#define EEL_IMG_MUTEXLOCK_SCOPE ysfx_image_scoped_lock lock{(ysfx_t *)(opaque)};

--- a/sources/ysfx_api_gfx.cpp
+++ b/sources/ysfx_api_gfx.cpp
@@ -341,13 +341,15 @@ void ysfx_gfx_enter(ysfx_t *fx, bool doinit)
             state->input_queue = {};
             state->keys_pressed = {};
 
-            // reset lice
             eel_lice_state *lice = state->lice.get();
-            LICE_WrapperBitmap framebuffer = *static_cast<LICE_WrapperBitmap *>(lice->m_framebuffer);
-            state->lice.reset();
-            lice = new eel_lice_state{fx->vm.get(), fx, ysfx_gfx_max_images, ysfx_gfx_max_fonts};
-            state->lice.reset(lice);
-            lice->m_framebuffer = new LICE_WrapperBitmap(framebuffer);
+
+            if (!lice) {
+                LICE_WrapperBitmap framebuffer = *static_cast<LICE_WrapperBitmap *>(lice->m_framebuffer);
+                state->lice.reset();
+                lice = new eel_lice_state{fx->vm.get(), fx, ysfx_gfx_max_images, ysfx_gfx_max_fonts};
+                state->lice.reset(lice);
+                lice->m_framebuffer = new LICE_WrapperBitmap(framebuffer);
+            };
 
             // load images from filenames
             uint32_t numfiles = (uint32_t)fx->source.main->header.filenames.size();

--- a/sources/ysfx_api_gfx_lice.hpp
+++ b/sources/ysfx_api_gfx_lice.hpp
@@ -577,6 +577,7 @@ static EEL_F * NSEEL_CGEN_CALL ysfx_api_gfx_blurto(void *opaque, EEL_F *x, EEL_F
 
 static EEL_F * NSEEL_CGEN_CALL ysfx_api_gfx_getimgdim(void *opaque, EEL_F *img, EEL_F *w, EEL_F *h)
 {
+  EEL_IMG_MUTEXLOCK_SCOPE
   eel_lice_state *ctx=EEL_LICE_GET_CONTEXT(opaque);
   if (ctx) ctx->gfx_getimgdim(*img,w,h);
   return img;
@@ -584,6 +585,7 @@ static EEL_F * NSEEL_CGEN_CALL ysfx_api_gfx_getimgdim(void *opaque, EEL_F *img, 
 
 static EEL_F NSEEL_CGEN_CALL ysfx_api_gfx_loadimg(void *opaque, EEL_F *img, EEL_F *fr)
 {
+  EEL_IMG_MUTEXLOCK_SCOPE
   eel_lice_state *ctx=EEL_LICE_GET_CONTEXT(opaque);
   if (ctx) return ctx->gfx_loadimg(opaque,(int)*img,*fr);
   return 0.0;
@@ -591,6 +593,7 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_gfx_loadimg(void *opaque, EEL_F *img, EEL_
 
 static EEL_F NSEEL_CGEN_CALL ysfx_api_gfx_setimgdim(void *opaque, EEL_F *img, EEL_F *w, EEL_F *h)
 {
+  EEL_IMG_MUTEXLOCK_SCOPE
   eel_lice_state *ctx=EEL_LICE_GET_CONTEXT(opaque);
   if (ctx) return ctx->gfx_setimgdim((int)*img,w,h);
   return 0.0;

--- a/sources/ysfx_api_reaper.cpp
+++ b/sources/ysfx_api_reaper.cpp
@@ -68,9 +68,12 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_slider_next_chg(void *opaque, EEL_F *index
     return -1;
 }
 
-static EEL_F NSEEL_CGEN_CALL ysfx_api_slider_automate(void *opaque, EEL_F *mask_or_slider_)
+static EEL_F NSEEL_CGEN_CALL ysfx_api_slider_automate(void *opaque, INT_PTR nparms, EEL_F **parms)
 {
     //NOTE: callable from @gfx thread
+    if (nparms == 0) return 0;
+
+    EEL_F *mask_or_slider_ = parms[0];
 
     ysfx_t *fx = REAPER_GET_INTERFACE(opaque);
     uint32_t slider = ysfx_get_slider_of_var(fx, mask_or_slider_);
@@ -83,6 +86,15 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_slider_automate(void *opaque, EEL_F *mask_
 
     fx->slider.automate_mask |= mask;
     fx->slider.change_mask |= mask;
+
+    if (nparms > 1) {
+        if (ysfx_eel_round<int32_t>(parms[1][0])) {
+            fx->slider.touch_mask &= ~mask;
+        } else {
+            fx->slider.touch_mask |= mask;
+        }
+    }
+
     return 0;
 }
 
@@ -464,7 +476,7 @@ void ysfx_api_init_reaper()
     NSEEL_addfunc_retptr("slider", 1, NSEEL_PProc_THIS, &ysfx_api_slider);
 
     NSEEL_addfunc_retval("slider_next_chg", 2, NSEEL_PProc_THIS, &ysfx_api_slider_next_chg);
-    NSEEL_addfunc_retval("slider_automate", 1, NSEEL_PProc_THIS, &ysfx_api_slider_automate);
+    NSEEL_addfunc_varparm("slider_automate", 1, NSEEL_PProc_THIS, &ysfx_api_slider_automate);
     NSEEL_addfunc_retval("sliderchange", 1, NSEEL_PProc_THIS, &ysfx_api_sliderchange);
     NSEEL_addfunc_retval("slider_show", 2, NSEEL_PProc_THIS, &ysfx_api_slider_show);
 


### PR DESCRIPTION
*Why this PR?*
It adds a bunch of functionality required to make mawi's EQ work.

- Ensures that LICE image loading is a on a mutex to prevent crashes if someone uses them in `@init`.
- Prevents automation from `@gfx` from triggering `@slider`.
- Support touch automation (second argument).
- Prevent lice from resetting its context every time `@init` is run.