### PR TITLE
plugin: show parameter names in the host

### DIFF
--- a/plugin/parameter.h
+++ b/plugin/parameter.h
@@ -45,10 +45,14 @@ public:
     float getValueForText(const juce::String &text) const override;
     bool wasUpdatedByHost();  // Fetches whether this was updated by host and resets it
 
+    juce::String getName(int maximumStringLength) const override;
+    juce::CriticalSection m_nameSection;
+
 private:
     ysfx_u m_fx;
     int m_sliderIndex = 0;
     float m_value = 0.0f;
     std::atomic<bool> m_hostUpdated{false};
+    juce::String m_displayName;
     const juce::NormalisableRange<float> m_range{0.0f, 1.0f};
 };

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -677,6 +677,8 @@ void YsfxProcessor::Impl::installNewFx(YsfxInfo::Ptr info)
     bool notify = false;
     syncSlidersToParameters(notify);
 
+    m_self->updateHostDisplay();
+
     // notify parameters later, on the message thread
     m_sliderParamsToNotify.store(~(uint64_t)0);
     m_sliderParamsTouching.store((uint64_t)0);


### PR DESCRIPTION
**Why this PR?**
It's nice to see the parameter names in the host.

![image](https://github.com/user-attachments/assets/2a99e30d-741e-4a23-89b4-a4167b35f737)
