### PR TITLE
ysfx/plugin: support 256 sliders properly

### DIFF
--- a/exports/ysfx.txt
+++ b/exports/ysfx.txt
@@ -56,6 +56,8 @@ ysfx_send_midi
 ysfx_receive_midi
 ysfx_receive_midi_from_bus
 ysfx_send_trigger
+ysfx_fetch_slider_group_index
+ysfx_slider_mask
 ysfx_fetch_slider_changes
 ysfx_fetch_slider_automations
 ysfx_fetch_slider_touches

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -56,6 +56,7 @@ enum {
     ysfx_max_channels = 64,
     ysfx_max_midi_buses = 16,
     ysfx_max_triggers = 10,
+    ysfx_max_slider_groups = 4,  // needs to be ysfx_max_sliders / 64
 };
 
 typedef enum ysfx_log_level_e {
@@ -276,14 +277,19 @@ YSFX_API bool ysfx_receive_midi_from_bus(ysfx_t *fx, uint32_t bus, ysfx_midi_eve
 // send a trigger, it will be processed during the cycle
 YSFX_API bool ysfx_send_trigger(ysfx_t *fx, uint32_t index);
 
+// determine which group a particular slider is part of
+YSFX_API size_t ysfx_fetch_slider_group_index(uint32_t slider_number);
+// generate a slider bitmask for a slider with which you can extract the relevant bit
+YSFX_API uint64_t ysfx_slider_mask(uint32_t slider_number, size_t group_index);
+
 // get a bit mask of sliders whose values must be redisplayed, and clear it to zero
-YSFX_API uint64_t ysfx_fetch_slider_changes(ysfx_t *fx);
+YSFX_API uint64_t ysfx_fetch_slider_changes(ysfx_t *fx, size_t slider_group_index);
 // get a bit mask of sliders whose values must be automated, and clear it to zero
-YSFX_API uint64_t ysfx_fetch_slider_automations(ysfx_t *fx);
+YSFX_API uint64_t ysfx_fetch_slider_automations(ysfx_t *fx, size_t slider_group_index);
 // get a bit mask of sliders whose values are currently being touched
-YSFX_API uint64_t ysfx_fetch_slider_touches(ysfx_t *fx);
+YSFX_API uint64_t ysfx_fetch_slider_touches(ysfx_t *fx, size_t slider_group_index);
 // get a bit mask of sliders currently visible
-YSFX_API uint64_t ysfx_get_slider_visibility(ysfx_t *fx);
+YSFX_API uint64_t ysfx_get_slider_visibility(ysfx_t *fx, size_t slider_group_index);
 
 // process a cycle in 32-bit float
 YSFX_API void ysfx_process_float(ysfx_t *fx, const float *const *ins, float *const *outs, uint32_t num_ins, uint32_t num_outs, uint32_t num_frames);

--- a/sources/ysfx.hpp
+++ b/sources/ysfx.hpp
@@ -145,10 +145,10 @@ struct ysfx_s {
 
     // Slider
     struct {
-        ysfx::sync_bitset64 automate_mask;
-        ysfx::sync_bitset64 change_mask;
-        ysfx::sync_bitset64 visible_mask;
-        ysfx::sync_bitset64 touch_mask;
+        ysfx::sync_bitset64 automate_mask[ysfx_max_slider_groups];
+        ysfx::sync_bitset64 change_mask[ysfx_max_slider_groups];
+        ysfx::sync_bitset64 visible_mask[ysfx_max_slider_groups];
+        ysfx::sync_bitset64 touch_mask[ysfx_max_slider_groups];
     } slider;
 
     // Triggers

--- a/tests/ysfx_test_slider.cpp
+++ b/tests/ysfx_test_slider.cpp
@@ -95,13 +95,17 @@ TEST_CASE("slider manipulation", "[sliders]")
             "slider5:0<0,1,0.1>-the slider 5" "\n"
             "slider6:0<0,1,0.1>-the slider 6" "\n"
             "slider7:0<0,1,0.1>the slider 7" "\n"
+            "slider254:0<0,1,0.1>-the slider 254" "\n"
+            "slider255:0<0,1,0.1>the slider 255" "\n"
             "@block" "\n"
             "slider_show(slider1,0);" "\n"
             "slider_show(slider2,1);" "\n"
             "slider_show(slider3,-1);" "\n"
             "slider_show(slider4,0);" "\n"
             "slider_show(slider5,1);" "\n"
-            "slider_show(slider6,-1);" "\n";
+            "slider_show(slider6,-1);" "\n"
+            "slider_show(slider254,1);" "\n"
+            "slider_show(slider255,-1);" "\n";
 
         scoped_new_dir dir_fx("${root}/Effects");
         scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
@@ -123,9 +127,9 @@ TEST_CASE("slider manipulation", "[sliders]")
         ysfx_init(fx.get());
 
         uint64_t visible = 0;
-        auto slider_is_visible = [&visible](uint32_t i) -> bool { return visible & ((uint64_t)1 << i); };
+        auto slider_is_visible = [&visible](uint32_t i) -> bool { return visible & ysfx_slider_mask(i, ysfx_fetch_slider_group_index(i)); };
 
-        visible = ysfx_get_slider_visibility(fx.get());
+        visible = ysfx_get_slider_visibility(fx.get(), 0);
         REQUIRE(slider_is_visible(0));
         REQUIRE(slider_is_visible(1));
         REQUIRE(slider_is_visible(2));
@@ -133,15 +137,23 @@ TEST_CASE("slider manipulation", "[sliders]")
         REQUIRE(!slider_is_visible(4));
         REQUIRE(!slider_is_visible(5));
 
+        visible = ysfx_get_slider_visibility(fx.get(), 3);
+        REQUIRE(!slider_is_visible(253));
+        REQUIRE(slider_is_visible(254));
+
         ysfx_process_float(fx.get(), nullptr, nullptr, 0, 0, 1);
 
-        visible = ysfx_get_slider_visibility(fx.get());
+        visible = ysfx_get_slider_visibility(fx.get(), 0);
         REQUIRE(!slider_is_visible(0));
         REQUIRE(slider_is_visible(1));
         REQUIRE(!slider_is_visible(2));
         REQUIRE(!slider_is_visible(3));
         REQUIRE(slider_is_visible(4));
         REQUIRE(slider_is_visible(5));
+
+        visible = ysfx_get_slider_visibility(fx.get(), 3);
+        REQUIRE(slider_is_visible(253));
+        REQUIRE(!slider_is_visible(254));
     }
 
     SECTION("slider changes")
@@ -152,9 +164,14 @@ TEST_CASE("slider manipulation", "[sliders]")
             "slider1:0<0,1,0.1>the slider 1" "\n"
             "slider2:0<0,1,0.1>the slider 2" "\n"
             "slider3:0<0,1,0.1>the slider 3" "\n"
+            "slider66:0<0,1,0.1>the slider 66" "\n"
+            "slider255:0<0,1,0.1>the slider 255" "\n"
+            "slider256:0<0,1,0.1>the slider 256" "\n"
             "@block" "\n"
             "sliderchange(slider1);" "\n"
-            "slider_automate(slider2);" "\n";
+            "slider_automate(slider2);" "\n"
+            "slider_automate(slider66);" "\n"
+            "sliderchange(slider256);" "\n";
 
         scoped_new_dir dir_fx("${root}/Effects");
         scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
@@ -179,25 +196,47 @@ TEST_CASE("slider manipulation", "[sliders]")
         uint64_t automated;
         uint64_t touched;
 
-        changed = ysfx_fetch_slider_changes(fx.get());
-        automated = ysfx_fetch_slider_automations(fx.get());
-        touched = ysfx_fetch_slider_touches(fx.get());
+        changed = ysfx_fetch_slider_changes(fx.get(), 0);
+        automated = ysfx_fetch_slider_automations(fx.get(), 0);
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(changed == 0);
         REQUIRE(automated == 0);
         REQUIRE(touched == 0);
 
         ysfx_process_float(fx.get(), nullptr, nullptr, 0, 0, 1);
 
-        changed = ysfx_fetch_slider_changes(fx.get());
-        automated = ysfx_fetch_slider_automations(fx.get());
-        touched = ysfx_fetch_slider_touches(fx.get());
+        changed = ysfx_fetch_slider_changes(fx.get(), 0);
+        automated = ysfx_fetch_slider_automations(fx.get(), 0);
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(changed == ((1 << 0) | (1 << 1)));
         REQUIRE(automated == (1 << 1));
         REQUIRE(touched == 0);
 
-        changed = ysfx_fetch_slider_changes(fx.get());
-        automated = ysfx_fetch_slider_automations(fx.get());
-        touched = ysfx_fetch_slider_touches(fx.get());
+        changed = ysfx_fetch_slider_changes(fx.get(), 1);
+        automated = ysfx_fetch_slider_automations(fx.get(), 1);
+        touched = ysfx_fetch_slider_touches(fx.get(), 1);
+        REQUIRE(changed == (1 << 1));
+        REQUIRE(automated == (1 << 1));
+        REQUIRE(touched == 0);
+
+        changed = ysfx_fetch_slider_changes(fx.get(), 2);
+        automated = ysfx_fetch_slider_automations(fx.get(), 2);
+        touched = ysfx_fetch_slider_touches(fx.get(), 2);
+        REQUIRE(changed == 0);
+        REQUIRE(automated == 0);
+        REQUIRE(touched == 0);
+
+        changed = ysfx_fetch_slider_changes(fx.get(), 3);
+        automated = ysfx_fetch_slider_automations(fx.get(), 3);
+        touched = ysfx_fetch_slider_touches(fx.get(), 3);
+        REQUIRE(changed == ysfx_slider_mask(255, 3));
+        REQUIRE(automated == 0);
+        REQUIRE(touched == 0);
+
+        // Automation and changes get reset after use
+        changed = ysfx_fetch_slider_changes(fx.get(), 0);
+        automated = ysfx_fetch_slider_automations(fx.get(), 0);
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(changed == 0);
         REQUIRE(automated == 0);
         REQUIRE(touched == 0);
@@ -211,8 +250,12 @@ TEST_CASE("slider manipulation", "[sliders]")
             "slider1:0<0,1,0.1>the slider 1" "\n"
             "slider2:0<0,1,0.1>the slider 2" "\n"
             "slider3:0<0,1,0.1>the slider 3" "\n"
+            "slider255:0<0,1,0.1>the slider 255" "\n"
+            "slider256:0<0,1,0.1>the slider 256" "\n"
             "@block" "\n"
-            "slider_automate(slider2, 0);" "\n";
+            "slider_automate(slider2, 0);" "\n"
+            "slider_automate(slider255, 0);" "\n"
+            "slider_automate(slider256, 0);" "\n";
 
         scoped_new_dir dir_fx("${root}/Effects");
         scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
@@ -228,11 +271,17 @@ TEST_CASE("slider manipulation", "[sliders]")
 
         uint64_t touched;
 
-        touched = ysfx_fetch_slider_touches(fx.get());
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(touched == (1 << 1));
 
-        touched = ysfx_fetch_slider_touches(fx.get());
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(touched == (1 << 1));  // Shouldn't clear!
+
+        touched = ysfx_fetch_slider_touches(fx.get(), 3);
+        REQUIRE(touched == (ysfx_slider_mask(254, 3) | ysfx_slider_mask(255, 3)));
+
+        touched = ysfx_fetch_slider_touches(fx.get(), 3);
+        REQUIRE(touched == (ysfx_slider_mask(254, 3) | ysfx_slider_mask(255, 3)));
     }
 
     SECTION("release touch")
@@ -243,9 +292,14 @@ TEST_CASE("slider manipulation", "[sliders]")
             "slider1:0<0,1,0.1>the slider 1" "\n"
             "slider2:0<0,1,0.1>the slider 2" "\n"
             "slider3:0<0,1,0.1>the slider 3" "\n"
+            "slider255:0<0,1,0.1>the slider 255" "\n"
+            "slider256:0<0,1,0.1>the slider 256" "\n"
             "@block" "\n"
             "slider_automate(slider2, 0);" "\n"
-            "slider_automate(slider2, 1);" "\n";
+            "slider_automate(slider2, 1);" "\n"
+            "slider_automate(slider255, 0);" "\n"
+            "slider_automate(slider255, 1);" "\n"
+            "slider_automate(slider256, 0);" "\n";
 
         scoped_new_dir dir_fx("${root}/Effects");
         scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
@@ -260,9 +314,13 @@ TEST_CASE("slider manipulation", "[sliders]")
         ysfx_process_float(fx.get(), nullptr, nullptr, 0, 0, 1);
 
         uint64_t touched;
-        touched = ysfx_fetch_slider_touches(fx.get());
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(touched == 0);
-        touched = ysfx_fetch_slider_touches(fx.get());
+        touched = ysfx_fetch_slider_touches(fx.get(), 0);
         REQUIRE(touched == 0);
+        touched = ysfx_fetch_slider_touches(fx.get(), 3);
+        REQUIRE(touched == ysfx_slider_mask(255, 3));
+        touched = ysfx_fetch_slider_touches(fx.get(), 3);
+        REQUIRE(touched == ysfx_slider_mask(255, 3));  // We didn't stop touching 255.
     }
 }


### PR DESCRIPTION
**Why this PR?**
Prior to these changes, the automation was technically broken for 256 sliders. This PR fixes these issues by using four 64-bit `bitmasks` instead of a single one.

It's a little rough around the edges, but it also adds tests for the `ysfx` part, so it can still be cleaned up.