### PR TITLE
plugin: ui improvements

### DIFF
--- a/plugin/components/parameters_panel.cpp
+++ b/plugin/components/parameters_panel.cpp
@@ -285,6 +285,7 @@ public:
                              slider.findColour(juce::Slider::textBoxOutlineColourId));
         valueLabel.setBorderSize({1, 1, 1, 1});
         valueLabel.setJustificationType(juce::Justification::centred);
+        valueLabel.setEditable(true);
         addAndMakeVisible(valueLabel);
 
         // Set the initial value.
@@ -293,6 +294,7 @@ public:
         slider.onValueChange = [this] { sliderValueChanged(); };
         slider.onDragStart = [this] { sliderStartedDragging(); };
         slider.onDragEnd = [this] { sliderStoppedDragging(); };
+        valueLabel.onTextChange = [this] { labelValueChanged(); };
     }
 
     void paint(juce::Graphics &) override
@@ -349,6 +351,23 @@ private:
     {
         isDragging = false;
         getParameter().endChangeGesture();
+    }
+
+    void labelValueChanged()
+    {
+        juce::String textValue{valueLabel.getText()};
+        const auto charptr = textValue.getCharPointer();
+        auto ptr = charptr;
+        auto newVal = juce::CharacterFunctions::readDoubleValue(ptr);
+        size_t chars_read = ptr - charptr;
+        
+        if (chars_read == textValue.getNumBytesAsUTF8()) {
+            if (getParameter().getValue() != newVal) {
+                getParameter().setValueNotifyingHost(getParameter().convertFromYsfxValue(newVal));
+            }
+        } else {
+            updateTextDisplay();
+        }
     }
 
     juce::Slider slider{juce::Slider::LinearHorizontal, juce::Slider::TextEntryBoxPosition::NoTextBox};

--- a/plugin/components/parameters_panel.cpp
+++ b/plugin/components/parameters_panel.cpp
@@ -367,10 +367,6 @@ public:
         parameterName.setText(parameter.getSliderName(), juce::dontSendNotification);
         parameterName.setJustificationType(juce::Justification::centredRight);
         addAndMakeVisible(parameterName);
-
-        parameterLabel.setText("slider" + juce::String(1 + parameter.getSliderIndex()), juce::dontSendNotification);
-        addAndMakeVisible(parameterLabel);
-
         addAndMakeVisible(*(parameterComp = createParameterComp()));
 
         setSize(400, 40);
@@ -382,16 +378,15 @@ public:
 
     void resized() override
     {
-        auto area = getLocalBounds();
+        auto area = getLocalBounds().withTrimmedRight(10);
 
-        parameterName.setBounds(area.removeFromLeft(200));
-        parameterLabel.setBounds(area.removeFromRight(100));
+        parameterName.setBounds(area.removeFromLeft(200 - std::max(0, 400 - area.getWidth())));
         parameterComp->setBounds(area);
     }
 
 private:
     YsfxParameter &parameter;
-    juce::Label parameterName, parameterLabel;
+    juce::Label parameterName;
     std::unique_ptr<Component> parameterComp;
 
     std::unique_ptr<Component> createParameterComp() const

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -180,7 +180,7 @@ void YsfxEditor::Impl::updateInfo()
     if (filePath != juce::File{}) {
         m_lblFilePath->setText(filePath.getFileNameWithoutExtension(), juce::dontSendNotification);
         m_lblFilePath->setTooltip(filePath.getFullPathName());
-        m_self->getTopLevelComponent()->setName(ysfx_get_name(fx));
+        m_self->getTopLevelComponent()->setName(juce::String(ysfx_get_name(fx)) + " (ysfx)");
     }
     else {
         m_lblFilePath->setText(TRANS("No file"), juce::dontSendNotification);
@@ -359,8 +359,8 @@ void YsfxEditor::Impl::popupRecentFiles()
         return;
 
     juce::PopupMenu::Options popupOptions = juce::PopupMenu::Options{}
-        .withParentComponent(m_self)
         .withTargetComponent(*m_btnRecentFiles);
+    
     m_recentFilesPopup->showMenuAsync(popupOptions, [this, recent](int index) {
         if (index == 1000)
             clearRecentFiles();
@@ -385,7 +385,6 @@ void YsfxEditor::Impl::popupPresets()
     }
 
     juce::PopupMenu::Options popupOptions = juce::PopupMenu::Options{}
-        .withParentComponent(m_self)
         .withTargetComponent(*m_btnLoadPreset);
     m_presetsPopup->showMenuAsync(popupOptions, [this, info](int index) {
         if (index > 0)

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -101,7 +101,7 @@ struct YsfxEditor::Impl {
 };
 
 static const int defaultEditorWidth = 700;
-static const int defaultEditorHeight = 600;
+static const int defaultEditorHeight = 50;
 
 YsfxEditor::YsfxEditor(YsfxProcessor &proc)
     : juce::AudioProcessorEditor(proc),
@@ -129,12 +129,14 @@ void YsfxEditor::paint (juce::Graphics& g)
 {
     // Redraw only parts that aren't covered already.
     const juce::Rectangle<int> bounds = getLocalBounds();
-    g.setColour(juce::Colours::black);
     g.setOpacity(1.0f);
-    g.fillRect(juce::Rectangle<int>(0, 0, bounds.getWidth(), 70));
-    g.fillRect(juce::Rectangle<int>(0, 0, 20, bounds.getHeight()));
-    g.fillRect(juce::Rectangle<int>(bounds.getWidth() - 20, 0, 20, bounds.getHeight()));
+    g.setColour(juce::Colour(0, 0, 0));
+    g.fillRect(juce::Rectangle<int>(0, 0, m_headerSize, bounds.getHeight() - m_headerSize));
+    g.fillRect(juce::Rectangle<int>(bounds.getWidth() - 20, m_headerSize, 20, bounds.getHeight() - m_headerSize));
     g.fillRect(juce::Rectangle<int>(0, bounds.getHeight() - 20, bounds.getWidth(), 20));
+
+    g.setColour(juce::Colour(32, 32, 32));
+    g.fillRect(juce::Rectangle<int>(0, 0, bounds.getWidth(), m_headerSize));
 }
 
 YsfxEditor::~YsfxEditor()
@@ -583,7 +585,8 @@ void YsfxEditor::Impl::relayoutUI()
     ysfx_get_gfx_dim(fx, gfxDim);
 
     int parameterHeight = m_miniParametersPanel->getRecommendedHeight(0);
-    if (parameterHeight) parameterHeight += 10;
+    int sideTrim{0};
+    int bottomTrim{0};
 
     if (m_mustResizeToGfx) {
         float scaling_factor = 1.0f;
@@ -591,8 +594,8 @@ void YsfxEditor::Impl::relayoutUI()
             scaling_factor = m_graphicsView->getTotalScaling();
         }
 
-        int w = juce::jmax(defaultEditorWidth, (int)(gfxDim[0] * scaling_factor) + 22);
-        int h = juce::jmax(defaultEditorHeight, (int)(gfxDim[1] * scaling_factor) + 50 + 20);
+        int w = juce::jmax(defaultEditorWidth, (int)(gfxDim[0] * scaling_factor) + 2 * sideTrim);
+        int h = juce::jmax(defaultEditorHeight, (int)(gfxDim[1] * scaling_factor) + m_self->m_headerSize + 2 * bottomTrim);
 
         m_self->setSize(w, h + parameterHeight);
         m_mustResizeToGfx = false;
@@ -602,8 +605,8 @@ void YsfxEditor::Impl::relayoutUI()
     const juce::Rectangle<int> bounds = m_self->getLocalBounds();
 
     temp = bounds;
-    const juce::Rectangle<int> topRow = temp.removeFromTop(50);
-    const juce::Rectangle<int> centerArea = temp.withTrimmedLeft(10).withTrimmedRight(10).withTrimmedBottom(10);
+    const juce::Rectangle<int> topRow = temp.removeFromTop(m_self->m_headerSize);
+    const juce::Rectangle<int> centerArea = temp.withTrimmedLeft(sideTrim).withTrimmedRight(sideTrim).withTrimmedBottom(bottomTrim);
 
     int width = 70;
     int spacing = 8;

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -180,6 +180,7 @@ void YsfxEditor::Impl::updateInfo()
     if (filePath != juce::File{}) {
         m_lblFilePath->setText(filePath.getFileNameWithoutExtension(), juce::dontSendNotification);
         m_lblFilePath->setTooltip(filePath.getFullPathName());
+        m_self->getTopLevelComponent()->setName(ysfx_get_name(fx));
     }
     else {
         m_lblFilePath->setText(TRANS("No file"), juce::dontSendNotification);

--- a/plugin/editor.h
+++ b/plugin/editor.h
@@ -30,6 +30,7 @@ protected:
     void paint (juce::Graphics& g) override;
 
 private:
+    int m_headerSize{45};
     struct Impl;
     std::unique_ptr<Impl> m_impl;
 };

--- a/plugin/lookandfeel.h
+++ b/plugin/lookandfeel.h
@@ -20,4 +20,37 @@
 
 class YsfxLookAndFeel : public juce::LookAndFeel_V4 {
 public:
+    YsfxLookAndFeel()
+    {
+        juce::Colour white = juce::Colours::white;
+        juce::Colour black = juce::Colours::black;
+        juce::Colour grayBg = juce::Colour(32, 32, 32);
+        juce::Colour grayElementBg = juce::Colour(16, 16, 16);
+
+        juce::Colour c1 = juce::Colour(255, 255, 255);
+        juce::Colour c2 = juce::Colour(222, 222, 222);
+
+        setColour(juce::DocumentWindow::backgroundColourId, grayBg);
+        setColour(juce::ComboBox::backgroundColourId, grayElementBg);
+        setColour(juce::ComboBox::buttonColourId, grayElementBg);
+
+        setColour(juce::TextButton::buttonColourId, grayElementBg);
+        setColour(juce::TextEditor::backgroundColourId, grayElementBg);
+
+        setColour(juce::ListBox::backgroundColourId, grayElementBg);
+        setColour(juce::ListBox::backgroundColourId, grayElementBg);
+
+        setColour(juce::ScrollBar::thumbColourId, c2);
+        setColour(juce::ScrollBar::trackColourId, c1);
+        setColour(juce::Slider::thumbColourId, c2);
+        setColour(juce::Slider::trackColourId, c1);
+        setColour(juce::Slider::backgroundColourId, grayElementBg);
+
+        setColour(juce::PopupMenu::backgroundColourId, grayElementBg);
+
+        setColour(juce::AlertWindow::backgroundColourId, juce::Colour(23, 23, 14));
+        
+        auto &scheme = getCurrentColourScheme();
+        scheme.setUIColour(ColourScheme::widgetBackground, juce::Colour(16, 16, 16));
+    }
 };

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -652,7 +652,6 @@ void YsfxProcessor::Impl::installNewFx(YsfxInfo::Ptr info)
     ysfx_t *fx = info->effect.get();
     m_fx.reset(fx);
     ysfx_add_ref(fx);
-    std::atomic_store(&m_info, info);
 
     ysfx_set_sample_rate(fx, m_sample_rate);
     ysfx_set_block_size(fx, m_block_size);
@@ -673,6 +672,8 @@ void YsfxProcessor::Impl::installNewFx(YsfxInfo::Ptr info)
         m_sliderParamsToNotify[i].store(~(uint64_t)0);
         m_sliderParamsTouching[i].store((uint64_t)0);
     }
+
+    std::atomic_store(&m_info, info);
     m_background->wakeUp();
 }
 


### PR DESCRIPTION
This PR adds the following functionality to the plugin:
- Show visible sliders above gfx area.
- Reduce unnecessary padding on the edges of the gfx area.
- Change some of the juce default look.
- Allow popup menu's to leave the plugin area.
- Support typing parameter values for sliders in the label box.