### PR TITLE
parameter rounding and missing plugin handling

### DIFF
--- a/plugin/components/parameters_panel.cpp
+++ b/plugin/components/parameters_panel.cpp
@@ -303,7 +303,7 @@ public:
 
     void resized() override
     {
-        auto area = getLocalBounds().reduced(0, 10);
+        auto area = getLocalBounds().reduced(10, 10);
 
         valueLabel.setBounds(area.removeFromRight(80));
 

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -712,12 +712,14 @@ void YsfxEditor::Impl::relayoutUI()
 
     juce::Component *viewed;
     if (m_btnSwitchEditor->getToggleState()) {
-        const juce::Rectangle<int> paramArea = centerArea.withHeight(parameterHeight);
+        int maxParamArea = m_self->getHeight();
+        if (fx && ysfx_has_section(fx, ysfx_section_gfx)) maxParamArea /= 2;
+        const juce::Rectangle<int> paramArea = centerArea.withHeight(std::min(parameterHeight, maxParamArea));
         const juce::Rectangle<int> gfxArea = centerArea.withTrimmedTop(parameterHeight);
 
         if (parameterHeight) {
             viewed = m_miniParametersPanel.get();
-            viewed->setSize(paramArea.getWidth(), paramArea.getHeight());
+            viewed->setSize(paramArea.getWidth(), m_miniParametersPanel->getRecommendedHeight(0));
             m_topViewPort->setBounds(paramArea);
             m_topViewPort->setViewedComponent(viewed, false);
             m_topViewPort->setVisible(true);

--- a/plugin/parameter.cpp
+++ b/plugin/parameter.cpp
@@ -81,6 +81,7 @@ ysfx_real YsfxParameter::convertToYsfxValue(float normValue) const
     //    to make sure imprecision does not land us on the wrong index
     if (isEnumSlider())
         actualValue = juce::roundToInt(actualValue);
+
     return actualValue;
 }
 
@@ -143,6 +144,13 @@ juce::String YsfxParameter::getText(float normalisedValue, int) const
         int index = juce::roundToInt(actualValue);
         if (index >= 0 && index < enumSize)
             return getSliderEnumName(index);
+    } else {
+        // NOTE: Unfortunately, things have to map to 0-1 so you lose some precision 
+        // coming back (and can't rely on integer floats being exact anymore).
+        ysfx_real rounded = juce::roundToInt(actualValue);
+        if (std::abs(rounded - actualValue) < 0.00001) {
+            actualValue = rounded > -0.1 ? abs(rounded) : rounded;
+        }
     }
 
     return juce::String(actualValue);

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -569,8 +569,17 @@ void YsfxProcessor::Impl::syncParameterToSlider(int index)
         return;
 
     YsfxParameter *param = m_self->getYsfxParameter(index);
+
     if (param->existsAsSlider()) {
         ysfx_real actualValue = param->convertToYsfxValue(param->getValue());
+        ysfx_slider_range_t range = param->getSliderRange();
+
+        // NOTE: Unfortunately, things have to map to 0-1 so you lose some precision 
+        // coming back (and can't rely on integer floats being exact anymore).
+        ysfx_real rounded = juce::roundToInt(actualValue);
+        if (std::abs(rounded - actualValue) < 0.00001) {
+            actualValue = rounded > -0.1 ? abs(rounded) : rounded;
+        }
 
         ysfx_slider_set_value(m_fx.get(), (uint32_t)index, actualValue, param->wasUpdatedByHost());
     }

--- a/plugin/processor.h
+++ b/plugin/processor.h
@@ -23,6 +23,8 @@ class YsfxParameter;
 using ysfx_t = struct ysfx_s;
 using ysfx_state_t = struct ysfx_state_s;
 
+enum RetryState {ok, mustRetry, retrying};
+
 class YsfxProcessor : public juce::AudioProcessor {
 public:
     YsfxProcessor();
@@ -64,6 +66,10 @@ public:
 
     //==========================================================================
     bool isBusesLayoutSupported(const BusesLayout &layout) const override;
+
+    // Did the last plugin fail to load and should we retry?
+    RetryState retryLoad();
+    juce::String lastLoadPath();
 
 private:
     struct Impl;


### PR DESCRIPTION
**Why this PR?**
- Rounds exposed parameter values that are very close to integer values. The reason this is needed is because JUCE internally stores floating point values between 0 and 1. We round analogously to reaper's `==` operator, which is using a tolerance of `0.00001`.
- Adds a feature where if a plugin is missing, the user is prompted to find it on disk. This allows the plugin to keep the last saved state.