### PR TITLE
ysfx: more permissive slider parsing

### DIFF
--- a/sources/ysfx_parse.cpp
+++ b/sources/ysfx_parse.cpp
@@ -288,7 +288,7 @@ bool ysfx_parse_slider(const char *line, ysfx_slider_t &slider)
                 ++cur;
                 slider.inc = (ysfx_real)ysfx::dot_strtod(cur, (char **)&cur);
 
-                while (*cur && *cur != '{' && *cur != ',' && *cur != '>' && *cur != ':') ++cur;
+                while (*cur && *cur != '{' && *cur != '>' && *cur != ':') ++cur;
                 if (!*cur) PARSE_FAIL;
 
                 // enumeration values

--- a/tests/ysfx_test_parse.cpp
+++ b/tests/ysfx_test_parse.cpp
@@ -369,6 +369,22 @@ TEST_CASE("slider parsing", "[parse]")
         ensure_regular_slider(slider, 42, {}, "log me", 20, 20, 22050.0, 0.01, 1, 5000);
     }
 
+    SECTION("log shape middle permissive")
+    {
+        const char *line = "slider43:20<20.0,22050,0.01,-.,#+,@abcd:log=5000>log me";
+        ysfx_slider_t slider;
+        REQUIRE(ysfx_parse_slider(line, slider));
+        ensure_regular_slider(slider, 42, {}, "log me", 20, 20, 22050.0, 0.01, 1, 5000);
+    }
+
+    SECTION("log shape middle even more permissive")
+    {
+        const char *line = "slider43:20<20.0,22050,0.01,-.,#+,@abcd:log=5000.#=1414?-+<,>log me";
+        ysfx_slider_t slider;
+        REQUIRE(ysfx_parse_slider(line, slider));
+        ensure_regular_slider(slider, 42, {}, "log me", 20, 20, 22050.0, 0.01, 1, 5000);
+    }
+
     SECTION("log shape capitalization")
     {
         const char *line = "slider43:20<20.0,22050,0.01:LOg>captains log";


### PR DESCRIPTION
This is a valid slider: `slider40:bust=0<10,5000,0.001,-.,#+,@abcd:log=100>yes`