### PR TITLE
plugin: allow more control over slider area

### DIFF
--- a/cmake.plugin.txt
+++ b/cmake.plugin.txt
@@ -73,6 +73,7 @@ target_sources(ysfx_plugin
         "plugin/components/ide_view.h"
         "plugin/components/searchable_popup.h"
         "plugin/components/modal_textinputbox.h"
+        "plugin/components/divider.h"
         "plugin/utility/audio_processor_suspender.h"
         "plugin/utility/functional_timer.h"
         "plugin/utility/async_updater.cpp"

--- a/plugin/components/divider.h
+++ b/plugin/components/divider.h
@@ -1,0 +1,76 @@
+#include <juce_gui_extra/juce_gui_extra.h>
+
+
+class Divider : public juce::Component
+{
+public:
+    Divider(Component* parent): component(parent)
+    {
+        setRepaintsOnMouseActivity(true);
+        setMouseCursor(juce::MouseCursor::UpDownResizeCursor);
+    }
+
+    void mouseDown (const juce::MouseEvent& e [[maybe_unused]])
+    {
+        m_startPosition = m_position;
+    }
+
+    void mouseUp(const juce::MouseEvent& e)
+    {
+        if (e.getNumberOfClicks() > 1) {
+            // Reset wasdragged so that this will snap back to default next layout update cycle.
+            m_wasDragged = false;
+            if (component) {
+                component->resized();
+            }
+        };
+    }
+
+    void mouseDrag(const juce::MouseEvent& e){
+        m_wasDragged = true;
+        m_position = std::min(m_maximumHeight, std::max(m_minimumHeight, m_startPosition + e.getDistanceFromDragStartY()));
+        if (component) {
+            component->resized();
+        }
+    }
+
+    void paint (juce::Graphics& g)
+    {
+        getLookAndFeel().drawStretchableLayoutResizerBar(g, getWidth(), getHeight(), true, isMouseOver(), isMouseButtonDown());
+    }
+
+    void setPosition(int position)
+    {
+        m_wasDragged = true;
+        m_position = position;
+    }
+
+    void setSizes(int recommendedHeight, int minimumHeight, int maximumHeight) {
+        m_minimumHeight = minimumHeight;
+        m_maximumHeight = maximumHeight;
+
+        if (!m_wasDragged) {
+            m_position = recommendedHeight;
+        }
+
+        m_position = std::min(m_maximumHeight, std::max(m_minimumHeight, m_position));
+    }
+
+    void resetDragged() {
+        m_wasDragged = false;
+    }
+
+    bool wasDragged() {
+        return m_wasDragged;
+    }
+
+    int m_position{200};
+    int m_startPosition{200};
+
+private:
+    juce::WeakReference<juce::Component> component;
+
+    int m_maximumHeight{4096};
+    int m_minimumHeight{200};
+    bool m_wasDragged{false};  // Once it has been dragged once, it overrides what the plugin asks for
+};


### PR DESCRIPTION
**Why this PR?**
If you have a long parameter list, you may want to control manually how much of the screen is covered with parameters.

- Fixes issue where initial scaling ignored DPI scaling.
- Added feature to allow users to change the amount of space that is used for the slider section above the graphics.
- Serializes what the user set as divider position.
- Sets a better default for the initial slider section size.