### PR TITLE
ysfx: make sure we use a plugin name

### DIFF
--- a/cmake.plugin.txt
+++ b/cmake.plugin.txt
@@ -39,78 +39,96 @@ if(YSFX_PLUGIN_VST3_SDK_PATH)
     juce_set_vst3_sdk_path("${YSFX_PLUGIN_VST3_SDK_PATH}")
 endif()
 
-juce_add_plugin(ysfx_plugin
-  PLUGIN_CODE "ysfx"
-  PLUGIN_MANUFACTURER_CODE "Jpci"
-  PRODUCT_NAME "ysfx_saike_mod"
-  COMPANY_NAME "Jean Pierre Cimalando / Joep Vanlier"
-  FORMATS VST3 AU
-  NEEDS_MIDI_INPUT TRUE
-  NEEDS_MIDI_OUTPUT TRUE
-  NEEDS_CURL FALSE
-  NEEDS_WEB_BROWSER FALSE
-  VST3_CATEGORIES "Fx"
-  AU_MAIN_TYPE "kAudioUnitType_Effect"
-  COPY_PLUGIN_AFTER_BUILD "${YSFX_PLUGIN_COPY}")
+function(add_new_target target_name is_synth)
+    if(${is_synth})
+        set(SUFFIX "")
+        set(CODE_END "y")
+        set(CATEGORY "Instrument")
+    else()
+        set(SUFFIX " FX")
+        set(CODE_END "z")
+        set(CATEGORY "Fx")
+    endif()
 
-target_sources(ysfx_plugin
+    juce_add_plugin("${target_name}"
+        PLUGIN_CODE "ysf${CODE_END}"
+        PLUGIN_MANUFACTURER_CODE "S4IK"
+        PRODUCT_NAME "ysfx-s${SUFFIX}"
+        JUCE_PLUGIN_NAME "ysfx-s${SUFFIX}"
+        JUCE_DESCRIPTION "Host for JSFX plugins"
+        COMPANY_NAME "Jean Pierre Cimalando / Joep Vanlier"
+        BUNDLE_ID "Jean_Pierre_Cimalando__Joep_Vanlier"
+        FORMATS VST3 AU
+        NEEDS_MIDI_INPUT TRUE
+        NEEDS_MIDI_OUTPUT TRUE
+        NEEDS_CURL FALSE
+        NEEDS_WEB_BROWSER FALSE
+        IS_SYNTH "${is_synth}"
+        VST3_CATEGORIES "${CATEGORY}"
+        AU_MAIN_TYPE "kAudioUnitType_Effect"
+        COPY_PLUGIN_AFTER_BUILD "${YSFX_PLUGIN_COPY}")
+
+    target_sources("${target_name}"
+        PRIVATE
+            "plugin/processor.cpp"
+            "plugin/processor.h"
+            "plugin/editor.cpp"
+            "plugin/editor.h"
+            "plugin/lookandfeel.cpp"
+            "plugin/lookandfeel.h"
+            "plugin/parameter.cpp"
+            "plugin/parameter.h"
+            "plugin/info.cpp"
+            "plugin/info.h"
+            "plugin/components/parameters_panel.cpp"
+            "plugin/components/parameters_panel.h"
+            "plugin/components/graphics_view.cpp"
+            "plugin/components/graphics_view.h"
+            "plugin/components/ide_view.cpp"
+            "plugin/components/ide_view.h"
+            "plugin/components/searchable_popup.h"
+            "plugin/components/modal_textinputbox.h"
+            "plugin/components/divider.h"
+            "plugin/utility/audio_processor_suspender.h"
+            "plugin/utility/functional_timer.h"
+            "plugin/utility/async_updater.cpp"
+            "plugin/utility/async_updater.h"
+            "plugin/utility/rt_semaphore.cpp"
+            "plugin/utility/rt_semaphore.h"
+            "plugin/utility/sync_bitset.hpp")
+
+    target_compile_definitions("${target_name}"
+    PUBLIC
+        "JUCE_WEB_BROWSER=0"
+        "JUCE_USE_CURL=0"
+        "JUCE_VST3_CAN_REPLACE_VST2=0")
+
+    target_include_directories("${target_name}"
+        PRIVATE
+            "plugin")
+
+    target_link_libraries("${target_name}"
     PRIVATE
-        "plugin/processor.cpp"
-        "plugin/processor.h"
-        "plugin/editor.cpp"
-        "plugin/editor.h"
-        "plugin/lookandfeel.cpp"
-        "plugin/lookandfeel.h"
-        "plugin/parameter.cpp"
-        "plugin/parameter.h"
-        "plugin/info.cpp"
-        "plugin/info.h"
-        "plugin/components/parameters_panel.cpp"
-        "plugin/components/parameters_panel.h"
-        "plugin/components/graphics_view.cpp"
-        "plugin/components/graphics_view.h"
-        "plugin/components/ide_view.cpp"
-        "plugin/components/ide_view.h"
-        "plugin/components/searchable_popup.h"
-        "plugin/components/modal_textinputbox.h"
-        "plugin/components/divider.h"
-        "plugin/utility/audio_processor_suspender.h"
-        "plugin/utility/functional_timer.h"
-        "plugin/utility/async_updater.cpp"
-        "plugin/utility/async_updater.h"
-        "plugin/utility/rt_semaphore.cpp"
-        "plugin/utility/rt_semaphore.h"
-        "plugin/utility/sync_bitset.hpp")
+        ysfx::ysfx
+        json
+        juce::juce_audio_processors
+        juce::juce_gui_basics
+        juce::juce_gui_extra
+        juce::juce_opengl
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_warning_flags)
 
-target_compile_definitions(ysfx_plugin
-  PUBLIC
-      "JUCE_WEB_BROWSER=0"
-      "JUCE_USE_CURL=0"
-      "JUCE_VST3_CAN_REPLACE_VST2=0"
-      "JUCE_DISPLAY_SPLASH_SCREEN=0")
+    if(YSFX_PLUGIN_LTO)
+        target_link_libraries("${target_name}" PRIVATE juce::juce_recommended_lto_flags)
+    endif()
 
-target_include_directories(ysfx_plugin
-    PRIVATE
-        "plugin")
+    if(YSFX_PLUGIN_FORCE_DEBUG)
+        target_compile_definitions("${target_name}" PRIVATE "JUCE_FORCE_DEBUG=1")
+    endif()
+endfunction()
 
-target_link_libraries(ysfx_plugin
-  PRIVATE
-      ysfx::ysfx
-      json
-      juce::juce_audio_processors
-      juce::juce_gui_basics
-      juce::juce_gui_extra
-      juce::juce_opengl
-      juce::juce_recommended_config_flags
-      juce::juce_recommended_warning_flags)
-
-if(YSFX_PLUGIN_LTO)
-    target_link_libraries(ysfx_plugin PRIVATE juce::juce_recommended_lto_flags)
-endif()
-
-if(YSFX_PLUGIN_FORCE_DEBUG)
-    target_compile_definitions(ysfx_plugin PRIVATE "JUCE_FORCE_DEBUG=1")
-endif()
+add_new_target(ysfx_plugin_instrument TRUE)
+add_new_target(ysfx_plugin FALSE)
 
 add_subdirectory(thirdparty/clap-juce-extensions EXCLUDE_FROM_ALL)
 

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -742,7 +742,7 @@ void YsfxEditor::Impl::initializeProperties()
 {
     juce::PropertiesFile::Options options;
 
-    options.applicationName = JucePlugin_Name;
+    options.applicationName = "ysfx_saike_mod";
     options.storageFormat = juce::PropertiesFile::StorageFormat::storeAsXML;
     options.filenameSuffix = ".prefs";
     options.osxLibrarySubFolder = "Application Support";


### PR DESCRIPTION
- Generate two plugins `ysfx-s` and `ysfx-s FX` such that hosts that make a distinction between an effect and instrument can use `ysfx` as both. This also makes sure that the `saike mod` can be installed side by side with classic `ysfx` from the main repo. Note that this means that projects going forward will use a new variant of the plugin.