### PR TITLE
ysfx: support `slider_show`

### DIFF
--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -275,22 +275,6 @@ float YsfxGraphicsView::getTotalScaling()
 
 void YsfxGraphicsView::paint(juce::Graphics &g)
 {
-    ysfx_t *fx = m_impl->m_fx.get();
-
-    if (!(fx && ysfx_has_section(fx, ysfx_section_gfx))) {
-        juce::Rectangle<int> bounds = getLocalBounds();
-
-        g.setColour(juce::Colours::white);
-        g.drawRect(bounds);
-
-        juce::Font font;
-        font.setHeight(32.0f);
-
-        g.setFont(font);
-        g.drawText(TRANS("No graphics"), bounds, juce::Justification::centred);
-        return;
-    }
-
     ///
     Impl::GfxTarget *target = m_impl->m_gfxTarget.get();
 

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -372,13 +372,14 @@ void YsfxProcessor::Impl::processBlockGenerically(const void *inputs[], void *ou
 {
     ysfx_t *fx = m_fx.get();
 
-    for (uint8_t group = 0; group < ysfx_max_slider_groups; group++) {
+    for (auto group = 0; group < ysfx_max_slider_groups; group++) {
         uint64_t sliderParametersChanged = m_sliderParametersChanged[group].exchange(0);
     
         if (sliderParametersChanged) {
-            for (int slider = 0; slider < ysfx_max_sliders; ++slider) {
-                if (sliderParametersChanged & ysfx_slider_mask((uint32_t) slider, group)) {
-                    syncParameterToSlider(slider);
+            auto group_offset = group << 6;
+            for (auto idx = 0; idx < 64; idx++) {
+                if (sliderParametersChanged & ((uint64_t)1 << idx)) {
+                    syncParameterToSlider(group_offset + idx);
                 }
             }
         }


### PR DESCRIPTION
*Changes*
- This PR adds support for `slider_show`
- Fixes a bug in updating slider values from the UI for sliders > 64
- Makes plugins default to the view where hidden sliders are actually hidden