### PR TITLE
plugin: don't open code window by default

### DIFF
--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -616,7 +616,7 @@ YSFX_DEFINE_AUTO_PTR(ysfx_menu_u, ysfx_menu_t, ysfx_menu_free);
         return sptr(ptr, sptr##_deleter());                      \
     }
 
-YSFX_DEFINE_SHARED_PTR(ysfx_bank_shared, ysfx_bank_t, ysfx_bank_free);
+YSFX_DEFINE_SHARED_PTR(ysfx_bank_shared, ysfx_bank_t, ysfx_bank_free)
 
 #endif // defined(__cplusplus) && (__cplusplus >= 201103L || (defined(_MSC_VER) && _MSVC_LANG >= 201103L))
 

--- a/plugin/components/ide_view.cpp
+++ b/plugin/components/ide_view.cpp
@@ -75,6 +75,7 @@ YsfxIDEView::YsfxIDEView()
     m_impl->relayoutUILater();
 
     m_impl->setupNewFx();
+    this->setVisible(false);
 }
 
 YsfxIDEView::~YsfxIDEView()

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -673,6 +673,12 @@ void YsfxEditor::Impl::switchEditor(bool showGfx)
 
 void YsfxEditor::Impl::openCodeEditor()
 {
+    if (!m_codeWindow) {
+        m_codeWindow.reset(new CodeWindow(TRANS("Edit"), m_self->findColour(juce::DocumentWindow::backgroundColourId), juce::DocumentWindow::allButtons));
+        m_codeWindow->setResizable(true, false);
+        m_codeWindow->setContentNonOwned(m_ideView.get(), true);
+    }
+
     m_codeWindow->setVisible(true);
     m_codeWindow->toFront(true);
     m_ideView->focusOnCodeEditor();
@@ -798,11 +804,7 @@ void YsfxEditor::Impl::createUI()
     m_miniParametersPanel.reset(new YsfxParametersPanel);
     m_graphicsView.reset(new YsfxGraphicsView);
     m_ideView.reset(new YsfxIDEView);
-    m_ideView->setVisible(true);
     m_ideView->setSize(1000, 600);
-    m_codeWindow.reset(new CodeWindow(TRANS("Edit"), m_self->findColour(juce::DocumentWindow::backgroundColourId), juce::DocumentWindow::allButtons));
-    m_codeWindow->setResizable(true, false);
-    m_codeWindow->setContentNonOwned(m_ideView.get(), true);
     m_tooltipWindow.reset(new juce::TooltipWindow);
 }
 


### PR DESCRIPTION
- Fixed a bug where on some window managers / DAWs the editor window would always appear (even without explicitly triggering it).