### PR TITLE
plugin: add option to flick forward and backward

### DIFF
--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -324,6 +324,9 @@ bool YsfxGraphicsView::keyPressed(const juce::KeyPress &key)
         inputs->m_ysfxKeys.emplace(kp.ymods, kp.ykey, true);
     }
 
+    // Pass escape through so users can close the plugin
+    if (key.getKeyCode() == key.escapeKey) return false;
+
     return true;
 }
 

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -627,9 +627,12 @@ void YsfxEditor::Impl::popupPresetOptions()
         m_presetsOptsPopup->addItem(1, "Save preset", true, false);
         m_presetsOptsPopup->addItem(2, "Rename preset", presetInfo->m_lastChosenPreset.isNotEmpty(), false);
         m_presetsOptsPopup->addSeparator();
-        m_presetsOptsPopup->addItem(3, "Delete preset", presetInfo->m_lastChosenPreset.isNotEmpty(), false);
+        m_presetsOptsPopup->addItem(3, "Next preset", true, false);
+        m_presetsOptsPopup->addItem(4, "Previous preset", true, false);
+        m_presetsOptsPopup->addSeparator();        
+        m_presetsOptsPopup->addItem(5, "Delete preset", presetInfo->m_lastChosenPreset.isNotEmpty(), false);
         m_presetsOptsPopup->addSeparator();
-        m_presetsOptsPopup->addItem(4, "Preset manager", true, false);
+        m_presetsOptsPopup->addItem(6, "Preset manager", true, false);
     }
 
     juce::PopupMenu::Options popupOptions = juce::PopupMenu::Options{}
@@ -688,6 +691,12 @@ void YsfxEditor::Impl::popupPresetOptions()
                     );
                     break;
                 case 3:
+                    m_proc->cyclePreset(1);
+                    break;
+                case 4:
+                    m_proc->cyclePreset(-1);
+                    break;                    
+                case 5:
                     // Delete
                     juce::AlertWindow::showAsync(
                         juce::MessageBoxOptions()
@@ -702,8 +711,9 @@ void YsfxEditor::Impl::popupPresetOptions()
                             }
                     );
                     break;
-                case 4:
+                case 6:
                     this->openPresetWindow();
+                    break;
                 default:
                     break;
             }

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -338,6 +338,37 @@ void YsfxProcessor::deleteCurrentPreset()
     loadJsfxPreset(m_impl->m_info, newBank, 0, false, true);
 }
 
+void YsfxProcessor::cyclePreset(int direction)
+{
+    if (!m_impl->m_bank) return;
+
+    // Look up current preset or default to last (since we consider it new)
+    auto currentPreset = m_impl->m_currentPresetInfo->m_lastChosenPreset;
+    auto bank = m_impl->m_bank.get();
+    auto max_preset = bank->preset_count;
+
+    if (max_preset < 1) return;
+    
+    uint32_t preset_index;
+    if (currentPreset.isEmpty()) {
+        preset_index = bank->preset_count;
+    } else {
+        preset_index = ysfx_preset_exists(bank, currentPreset.toStdString().c_str());
+        if (preset_index > 0) {
+            preset_index -= 1;
+        }
+    }
+    
+    int next_preset = static_cast<int>(preset_index) + direction;
+    if (next_preset < 0) {
+        next_preset = bank->preset_count - 1;
+    } else if (next_preset >= static_cast<int>(bank->preset_count)) {
+        next_preset = 0;
+    }
+
+    loadJsfxPreset(m_impl->m_info, m_impl->m_bank, next_preset, true, true);
+}
+
 YsfxInfo::Ptr YsfxProcessor::getCurrentInfo()
 {
     return std::atomic_load(&m_impl->m_info);

--- a/plugin/processor.h
+++ b/plugin/processor.h
@@ -36,6 +36,7 @@ public:
     bool presetExists(const char *preset_name);
     void reloadBank();
     void savePreset(const char* preset_name, ysfx_state_t *preset, bool load);
+    void cyclePreset(int direction);
     void saveCurrentPreset(const char* preset_name);
     void renameCurrentPreset(const char *new_preset_name);
     void deleteCurrentPreset();


### PR DESCRIPTION
*Changes*
- Adds option move between presets in preset sub-menu.
- Fixes a bug where the escape key was not bubbled up (meaning it was not possible to close the plugin UI with the escape key).