### PR TITLE
preset_mgr: rename and load from preset browser

### DIFF
--- a/plugin/components/modal_textinputbox.h
+++ b/plugin/components/modal_textinputbox.h
@@ -18,7 +18,7 @@ class ExclusionFilter : public juce::TextEditor::InputFilter
 };
 
 
-static void show_async_text_input(juce::String title, juce::String message, std::function<void(juce::String, bool)> callback, std::optional<std::function<juce::String(juce::String)>> validator=std::nullopt)
+static juce::AlertWindow* show_async_text_input(juce::String title, juce::String message, std::function<void(juce::String, bool)> callback, std::optional<std::function<juce::String(juce::String)>> validator=std::nullopt)
 {
     auto* window = new juce::AlertWindow(title, message, juce::AlertWindow::NoIcon);
     window->addTextEditor("textField", "", "");
@@ -39,10 +39,16 @@ static void show_async_text_input(juce::String title, juce::String message, std:
                 }
             }
 
-            callback(textEditor->getText(), true); window->exitModalState(0);
+            callback(textEditor->getText(), true);
+            window->exitModalState(0);
+            window->setVisible(false);
         };
     };
-    auto finalize_cancel = [window, textEditor, callback]() { callback(textEditor->getText(), false); window->exitModalState(0); };
+    auto finalize_cancel = [window, textEditor, callback]() {
+        callback(textEditor->getText(), false);
+        window->exitModalState(0);
+        window->setVisible(false);
+    };
 
     textEditor->onReturnKey = finalize_success;
     window->addButton("Ok", 1);
@@ -51,7 +57,9 @@ static void show_async_text_input(juce::String title, juce::String message, std:
     window->getButton("Cancel")->onClick = finalize_cancel;
 
     window->setAlwaysOnTop(true);
-    window->enterModalState(true, nullptr, true);
+    window->enterModalState(true, nullptr, false);
     textEditor->setWantsKeyboardFocus(true);
     textEditor->grabKeyboardFocus();
+
+    return window;
 }

--- a/plugin/components/rpl_view.h
+++ b/plugin/components/rpl_view.h
@@ -24,7 +24,8 @@ public:
     YsfxRPLView();
     ~YsfxRPLView() override;
     void setEffect(ysfx_t *fx);
-    void setBankUpdateCallback(std::function<void(void)> callback);
+    void setBankUpdateCallback(std::function<void(void)> bankUpdateCallback);
+    void setLoadPresetCallback(std::function<void(std::string)> loadPresetCallback);
 
     void focusOnPresetViewer();
 

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -410,7 +410,7 @@ void YsfxEditor::Impl::updateInfo()
 
             auto index = ysfx_preset_exists(bank.get(), preset.c_str());
             if (index > 0) {
-                m_proc->loadJsfxPreset(info, bank, (uint32_t)(index - 1), true, true);
+                m_proc->loadJsfxPreset(info, bank, (uint32_t)(index - 1), PresetLoadMode::load, true);
             }
         }
     );
@@ -759,7 +759,7 @@ void YsfxEditor::Impl::popupPresets()
 
     showPopupMenuWithQuickSearch(*m_presetsPopup, quickSearchOptions, [this, info, bank](int index) {
             if ((index > 0) && (index < 32767)) {
-                m_proc->loadJsfxPreset(info, bank, (uint32_t)(index - 1), true, true);
+                m_proc->loadJsfxPreset(info, bank, (uint32_t)(index - 1), PresetLoadMode::load, true);
             }
         }
     );

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -401,6 +401,18 @@ void YsfxEditor::Impl::updateInfo()
             m_proc->reloadBank();
         }
     );
+    m_rplView->setLoadPresetCallback(
+        [this](std::string preset) {
+            YsfxInfo::Ptr info = m_info;
+            ysfx_bank_shared bank = m_bank;
+            if (!bank) return;
+
+            auto index = ysfx_preset_exists(bank.get(), preset.c_str());
+            if (index > 0) {
+                m_proc->loadJsfxPreset(info, bank, (uint32_t)(index - 1), true, true);
+            }
+        }
+    );
 
     // We always just want the sliders the user meant to expose
     switchEditor(true);

--- a/plugin/processor.h
+++ b/plugin/processor.h
@@ -24,6 +24,7 @@ using ysfx_t = struct ysfx_s;
 using ysfx_state_t = struct ysfx_state_s;
 
 enum RetryState {ok, mustRetry, retrying};
+enum PresetLoadMode {load, noLoad, deleteName};
 
 class YsfxProcessor : public juce::AudioProcessor {
 public:
@@ -32,10 +33,10 @@ public:
 
     YsfxParameter *getYsfxParameter(int sliderIndex);
     void loadJsfxFile(const juce::String &filePath, ysfx_state_t *initialState, bool async);
-    void loadJsfxPreset(YsfxInfo::Ptr info, ysfx_bank_shared bank, uint32_t index, bool load, bool async);
+    void loadJsfxPreset(YsfxInfo::Ptr info, ysfx_bank_shared bank, uint32_t index, PresetLoadMode load, bool async);
     bool presetExists(const char *preset_name);
     void reloadBank();
-    void savePreset(const char* preset_name, ysfx_state_t *preset, bool load);
+    void savePreset(const char* preset_name, ysfx_state_t *preset);
     void cyclePreset(int direction);
     void saveCurrentPreset(const char* preset_name);
     void renameCurrentPreset(const char *new_preset_name);


### PR DESCRIPTION
- Adds the option to load presets from the preset browser by double clicking
- Adds option to rename preset from the preset browser with the right mouse button
- Fixes a potential crash that could happen when the main window is closed if a rename or save text box is open