### PR TITLE
ysfx: report internal state change to daw (wip)

### DIFF
--- a/exports/ysfx.txt
+++ b/exports/ysfx.txt
@@ -75,6 +75,7 @@ ysfx_fetch_slider_changes
 ysfx_fetch_slider_automations
 ysfx_fetch_slider_touches
 ysfx_get_slider_visibility
+ysfx_fetch_want_undopoint
 ysfx_process_float
 ysfx_process_double
 ysfx_load_state

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -339,6 +339,8 @@ YSFX_API uint64_t ysfx_fetch_slider_automations(ysfx_t *fx, uint8_t slider_group
 YSFX_API uint64_t ysfx_fetch_slider_touches(ysfx_t *fx, uint8_t slider_group_index);
 // get a bit mask of sliders currently visible
 YSFX_API uint64_t ysfx_get_slider_visibility(ysfx_t *fx, uint8_t slider_group_index);
+// determine whether the plugin wants a manual undo point made and clear it to false
+YSFX_API bool ysfx_fetch_want_undopoint(ysfx_t *fx);
 
 // process a cycle in 32-bit float
 YSFX_API void ysfx_process_float(ysfx_t *fx, const float *const *ins, float *const *outs, uint32_t num_ins, uint32_t num_outs, uint32_t num_frames);

--- a/plugin/parameter.cpp
+++ b/plugin/parameter.cpp
@@ -18,6 +18,11 @@
 #include "parameter.h"
 #include <cmath>
 
+DummyParameter::DummyParameter(void) : AudioParameterFloat("__state_change_parameter__", "Internal state change", 0.0f, 1.0f, 0.5f) {};
+bool DummyParameter::isAutomatable(void) const {
+    return false;
+};
+
 YsfxParameter::YsfxParameter(ysfx_t *fx, int sliderIndex)
     : RangedAudioParameter(
         "slider" + juce::String(sliderIndex + 1),

--- a/plugin/parameter.h
+++ b/plugin/parameter.h
@@ -19,6 +19,13 @@
 #include "ysfx.h"
 #include <juce_audio_processors/juce_audio_processors.h>
 
+// Dummy parameter to force state saving
+class DummyParameter final : public juce::AudioParameterFloat {
+    public:
+        explicit DummyParameter();
+        bool isAutomatable() const override;
+};
+
 class YsfxParameter final : public juce::RangedAudioParameter {
 public:
     explicit YsfxParameter(ysfx_t *fx, int sliderIndex);

--- a/plugin/processor.cpp
+++ b/plugin/processor.cpp
@@ -83,6 +83,7 @@ struct YsfxProcessor::Impl : public juce::AudioProcessorListener {
 
     LoadRequest::Ptr m_loadRequest;
     PresetRequest::Ptr m_presetRequest;
+    bool m_wantUndoPoint{false};
     ysfx::sync_bitset64 m_sliderParamsToNotify[ysfx_max_slider_groups];
     ysfx::sync_bitset64 m_sliderParamsTouching[ysfx_max_slider_groups];
     bool m_updateParamNames{false};
@@ -120,6 +121,18 @@ struct YsfxProcessor::Impl : public juce::AudioProcessorListener {
     };
 
     std::unique_ptr<DeferredUpdateHostDisplay> m_deferredUpdateHostDisplay;
+
+    class ManualUndoPointUpdater : public juce::AsyncUpdater {
+        public:
+            explicit ManualUndoPointUpdater(Impl *impl) : m_impl{impl} {}
+
+        protected:
+            void handleAsyncUpdate() override;
+        
+        private:
+            Impl *m_impl = nullptr;
+    };
+    std::unique_ptr<ManualUndoPointUpdater> m_manualUndoPointUpdater;
 
     //==========================================================================
     class Background {
@@ -218,6 +231,9 @@ YsfxProcessor::YsfxProcessor()
 
     ///
     m_impl->m_deferredUpdateHostDisplay.reset(new Impl::DeferredUpdateHostDisplay(m_impl.get()));
+
+    ///
+    m_impl->m_manualUndoPointUpdater.reset(new Impl::ManualUndoPointUpdater(m_impl.get()));
 
     ///
     m_impl->m_background.reset(new Impl::Background(m_impl.get()));
@@ -743,6 +759,11 @@ void YsfxProcessor::Impl::processSliderChanges()
         notify = automated ? true : notify;
     };
 
+    m_wantUndoPoint = m_wantUndoPoint | ysfx_fetch_want_undopoint(fx);
+    if (m_wantUndoPoint) {
+        notify = true;
+    };
+
     // this will sync parameters later (on message thread)
     if (notify) m_background->wakeUp();
 
@@ -929,6 +950,7 @@ void YsfxProcessor::Impl::installNewFx(YsfxInfo::Ptr info, ysfx_bank_shared bank
         m_sliderParamsTouching[i].store((uint64_t)0);
     }
     m_updateParamNames = true;
+    m_wantUndoPoint = false;
 
     YsfxCurrentPresetInfo::Ptr presetInfo{new YsfxCurrentPresetInfo()};
     std::atomic_store(&m_currentPresetInfo, presetInfo);
@@ -1010,6 +1032,11 @@ void YsfxProcessor::Impl::DeferredUpdateHostDisplay::handleAsyncUpdate()
 {
     m_impl->m_self->updateHostDisplay(ChangeDetails().withParameterInfoChanged(true));
 }
+    
+void YsfxProcessor::Impl::ManualUndoPointUpdater::handleAsyncUpdate()
+{
+    m_impl->m_self->updateHostDisplay(ChangeDetails().withNonParameterStateChanged(true));
+}
 
 //==============================================================================
 YsfxProcessor::Impl::Background::Background(Impl *impl)
@@ -1054,6 +1081,12 @@ void YsfxProcessor::Impl::Background::run()
             processLoadRequest(*loadRequest);
         if (PresetRequest::Ptr presetRequest = std::atomic_exchange(&m_impl->m_presetRequest, PresetRequest::Ptr{}))
             processPresetRequest(*presetRequest);
+        
+        if (m_impl->m_wantUndoPoint) {
+            m_impl->m_wantUndoPoint = false;
+            Impl::ManualUndoPointUpdater *undoPointUpdater = m_impl->m_manualUndoPointUpdater.get();
+            undoPointUpdater->triggerAsyncUpdate();
+        }
     }
 }
 

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -1363,6 +1363,13 @@ uint64_t ysfx_fetch_slider_automations(ysfx_t *fx, uint8_t slider_group_index)
     return fx->slider.automate_mask[slider_group_index].exchange(0);
 }
 
+bool ysfx_fetch_want_undopoint(ysfx_t *fx)
+{
+    bool undo_point = fx->want_undo;
+    fx->want_undo = false;
+    return undo_point;
+}
+
 uint64_t ysfx_fetch_slider_touches(ysfx_t *fx, uint8_t slider_group_index)
 {
     return fx->slider.touch_mask[slider_group_index].load();

--- a/sources/ysfx.hpp
+++ b/sources/ysfx.hpp
@@ -69,6 +69,7 @@ struct ysfx_s {
     bool must_compute_init = false;
     bool must_compute_slider = false;
     bool has_serialize = false;
+    bool want_undo = false;
 
     std::unordered_map<ysfx_real *, uint32_t> slider_of_var;
     

--- a/sources/ysfx_api_reaper.cpp
+++ b/sources/ysfx_api_reaper.cpp
@@ -108,6 +108,13 @@ static EEL_F NSEEL_CGEN_CALL ysfx_api_sliderchange(void *opaque, EEL_F *mask_or_
     //NOTE: callable from @gfx thread
 
     ysfx_t *fx = REAPER_GET_INTERFACE(opaque);
+
+    bool wantUndo = static_cast<int64_t>(*mask_or_slider_) == -1;
+    if (wantUndo) {
+        fx->want_undo = true;
+        return 0;
+    }
+
     uint32_t slider = ysfx_get_slider_of_var(fx, mask_or_slider_);
 
     uint8_t group;

--- a/tests/ysfx_test_slider.cpp
+++ b/tests/ysfx_test_slider.cpp
@@ -159,6 +159,35 @@ TEST_CASE("slider manipulation", "[sliders]")
         REQUIRE(!slider_is_visible(254));
     }
 
+    SECTION("push_undo_point")
+    {
+        const char *text =
+            "desc:example" "\n"
+            "out_pin:output" "\n"
+            "@block" "\n"
+            "sliderchange(-1);" "\n";
+
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
+
+        ysfx_config_u config{ysfx_config_new()};
+        ysfx_u fx{ysfx_new(config.get())};
+
+        REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+        REQUIRE(ysfx_compile(fx.get(), 0));
+
+        ysfx_init(fx.get());
+        REQUIRE(ysfx_fetch_want_undopoint(fx.get()) == false);
+
+        ysfx_process_float(fx.get(), nullptr, nullptr, 0, 0, 1);
+        REQUIRE(ysfx_fetch_want_undopoint(fx.get()) == true);
+        REQUIRE(ysfx_fetch_want_undopoint(fx.get()) == false);
+
+        ysfx_process_float(fx.get(), nullptr, nullptr, 0, 0, 1);
+        REQUIRE(ysfx_fetch_want_undopoint(fx.get()) == true);
+        REQUIRE(ysfx_fetch_want_undopoint(fx.get()) == false);
+    }
+
     SECTION("slider changes")
     {
         const char *text =


### PR DESCRIPTION
It would be nice to save an undo history, but unfortunately this is complicated. The issue to work around is that most DAWs (e.g. ableton and bitwig) do not call `getStateInformation`/`setStateInformation` when calling `updateHostDisplay(ChangeDetails().withNonParameterStateChanged(true))`. This does work in REAPER though.

You can get bitwig to store an undo point if you rename a parameter, but this is likely to cause bad issues down the road. Only changing a value seems insufficient.

It might be worth exploring exposing a fake parameter that basically triggers a `ysfx_save_state` that we store ourselves.