### PR TITLE
ysfx: allow whitespace before slider identifier

### DIFF
--- a/sources/ysfx_parse.cpp
+++ b/sources/ysfx_parse.cpp
@@ -250,6 +250,9 @@ bool ysfx_parse_slider(const char *line, ysfx_slider_t &slider)
     // semicolon
     if (*cur++ != ':')
         PARSE_FAIL;
+    
+    // Whitespace before the identifier is ignored
+    while (*cur && ysfx::ascii_isspace(*cur)) ++cur;
 
     // search if there is an '=' sign prior to any '<' or ','
     // if there is, it's a custom variable

--- a/tests/ysfx_test_parse.cpp
+++ b/tests/ysfx_test_parse.cpp
@@ -515,6 +515,9 @@ TEST_CASE("slider parsing", "[parse]")
                 "slider10:a1?+!%&<-150%&=/?+!,12!%/&?+=,1=/?+!%&>?+!%&=/",
                 "SLIDER11:shouty=0<-150,12,1>shouty",
                 "SlIdEr12:infantile=0<-150,12,1>hehe",
+                "slider13: compRatio=0<-150,12,1> Ratio [x:1]",
+                "slider14:  compRatio2=0<-150,12,1> Ratio [x:1]",
+                "slider15:  all_the_spaces   = 0 < -150 , 12 , 1    > Ratio [x:1]",
             })
         {
             ysfx_slider_t slider;


### PR DESCRIPTION
Some JSFX use whitespace after the `:` and before the identifier name. Since reaper supports this, we should too.

An example of a JSFX that uses this can be found here: https://github.com/chkhld/jsfx/blob/main/Dynamics/track_comp.jsfx