### PR TITLE
ide: maintain state on compile error

### DIFF
--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -450,7 +450,7 @@ void YsfxEditor::Impl::updateInfo()
     if (!m_maintainState) switchEditor(true);
 
     juce::File file{juce::CharPointer_UTF8{ysfx_get_file_path(fx)}};
-    m_mustResizeToGfx = true;
+    m_mustResizeToGfx = !m_maintainState;
 
     loadScaling();
     relayoutUILater();
@@ -1038,7 +1038,10 @@ void YsfxEditor::Impl::connectUI()
         }
     };
 
-    m_ideView->onFileSaved = [this](const juce::File &file) { loadFile(file, true); };
+    m_ideView->onFileSaved = [this](const juce::File &file) { 
+        saveScaling();
+        loadFile(file, true);
+    };
 
     m_infoTimer.reset(FunctionalTimer::create([this]() { grabInfoAndUpdate(); }));
     m_infoTimer->startTimer(100);

--- a/plugin/processor.h
+++ b/plugin/processor.h
@@ -23,7 +23,7 @@ class YsfxParameter;
 using ysfx_t = struct ysfx_s;
 using ysfx_state_t = struct ysfx_state_s;
 
-enum RetryState {ok, mustRetry, retrying};
+enum RetryState {ok, mustRetry, retrying, failedRetry};
 enum PresetLoadMode {load, noLoad, deleteName};
 enum UndoRequest {noRequest, wantUndo, wantRedo};
 


### PR DESCRIPTION
- Shows compilation errors in the main window as they are easy to miss in the edit window (if it isn't open for example)
- Preserves state when saving from the IDE such that slider values and serialized data is not lost
- Stores viewport size when saving from the IDE prior to triggering the reload