### PR TITLE
plugin: fix transparency issue error label

### DIFF
--- a/plugin/components/graphics_view.h
+++ b/plugin/components/graphics_view.h
@@ -47,6 +47,7 @@ protected:
 private:
     std::atomic<float> m_pixelFactor{1.0f};
     std::atomic<float> m_outputScalingFactor{1.0f};
+    bool fullPixelScaling{true};
 
     struct Impl;
     std::unique_ptr<Impl> m_impl;

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -235,17 +235,10 @@ void YsfxEditor::readTheme()
 
 void YsfxEditor::paint (juce::Graphics& g)
 {
-    // Redraw only parts that aren't covered already.
     const juce::Rectangle<int> bounds = getLocalBounds();
-    g.setOpacity(1.0f);
-    g.setColour(juce::Colour(0, 0, 0));
-    g.fillRect(juce::Rectangle<int>(0, 0, m_headerSize, bounds.getHeight() - m_headerSize));
-    g.fillRect(juce::Rectangle<int>(bounds.getWidth() - 20, m_headerSize, 20, bounds.getHeight() - m_headerSize));
-    g.fillRect(juce::Rectangle<int>(0, bounds.getHeight() - 20, bounds.getWidth(), 20));
-
-    g.setColour(juce::Colour(32, 32, 32));
+    g.fillAll(juce::Colours::black);
     g.setColour(this->findColour(juce::DocumentWindow::backgroundColourId));
-    g.fillRect(juce::Rectangle<int>(0, 0, bounds.getWidth(), m_headerSize));
+    g.fillRect(juce::Rectangle<int>(0, 0, bounds.getWidth(), m_headerSize + 1));
 }
 
 YsfxEditor::~YsfxEditor()

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -59,6 +59,7 @@ struct YsfxEditor::Impl {
     bool m_mustResizeToGfx = true;
     bool m_maintainState = false;
     int m_keepUndoState{1};
+    int m_softwareRenderer{0};
     float m_currentScaling{1.0f};
     uint64_t m_sliderVisible[ysfx_max_slider_groups]{0};
     bool m_visibleSlidersChanged{false};
@@ -162,6 +163,16 @@ YsfxEditor::YsfxEditor(YsfxProcessor &proc)
     m_impl->updateInfo();
 
     readTheme();
+}
+
+void YsfxEditor::parentHierarchyChanged()
+{
+    if (m_impl->m_softwareRenderer) {
+        if (auto peer = getPeer())
+        {
+            peer->setCurrentRenderingEngine(0);
+        }
+    }
 }
 
 void writeThemeFile(juce::File file, std::map<std::string, std::array<uint8_t, 3>> colors, std::map<std::string, float> params)
@@ -914,6 +925,14 @@ void YsfxEditor::Impl::initializeProperties()
             m_keepUndoState = m_pluginProperties->getIntValue(key);
         } else {
             m_pluginProperties->setValue(key, 1);
+            m_pluginProperties->setNeedsToBeSaved(true);
+        }
+
+        auto sw_key = juce::String("ysfx_force_software_rendering");
+        if (m_pluginProperties->containsKey(sw_key)) {
+            m_softwareRenderer = m_pluginProperties->getIntValue(sw_key);
+        } else {
+            m_pluginProperties->setValue(sw_key, 0);
             m_pluginProperties->setNeedsToBeSaved(true);
         }
     }

--- a/plugin/editor.h
+++ b/plugin/editor.h
@@ -28,6 +28,7 @@ public:
 protected:
     void resized() override;
     void paint (juce::Graphics& g) override;
+    void parentHierarchyChanged() override;
     bool isInterestedInFileDrag(const juce::StringArray &files) override;
     void filesDropped(const juce::StringArray &files, int x, int y) override;
 


### PR DESCRIPTION
Error label renders transparently. This is unintended. While fixing this, I noticed that two slivers of pixels are missed when rendering the background, so draw those as well now.