### PR TITLE
plugin: fix crash bug when modifications are detected

### DIFF
--- a/plugin/components/ide_view.cpp
+++ b/plugin/components/ide_view.cpp
@@ -154,13 +154,14 @@ void YsfxIDEView::focusOfChildComponentChanged(FocusChangeType cause)
 
     if (m_impl->getCurrentEditor()->hasFocus()) {
         juce::Timer *timer = FunctionalTimer::create([this]() { 
-            m_impl->getCurrentEditor()->checkFileForModifications();
-
             int idx = 0;
-            for (auto& m : m_impl->m_editors) {
+            for (const auto& m : m_impl->m_editors) {
                 m_impl->m_tabs->setTabName(idx, m->getDisplayName());
                 ++idx;
             }
+
+            // Triggers a timer reset due to focus change, so must be last!
+            m_impl->getCurrentEditor()->checkFileForModifications();
         });
         m_impl->m_fileCheckTimer.reset(timer);
         timer->startTimer(100);


### PR DESCRIPTION
- Fixes a crash bug that would occur when a file open in the editor was modified outside the editor.