### PR TITLE
ysfx: provide stubs for functions we do not support

### DIFF
--- a/cmake.ysfx.txt
+++ b/cmake.ysfx.txt
@@ -52,6 +52,7 @@ add_library(ysfx-private
         "sources/ysfx_api_gfx.cpp"
         "sources/ysfx_api_gfx.hpp"
         "sources/ysfx_api_gfx_dummy.hpp"
+        "sources/ysfx_api_host_interaction_dummy.hpp"
         "sources/ysfx_api_gfx_lice.hpp"
         "sources/ysfx_eel_utils.cpp"
         "sources/ysfx_eel_utils.hpp"

--- a/plugin/components/tokenizer.cpp
+++ b/plugin/components/tokenizer.cpp
@@ -11,7 +11,7 @@ void JSFXTokenizer::setColours(std::map<std::string, std::array<uint8_t, 3>> col
     std::vector<std::string> ideColors{
         "error", "comment", "builtin_variable", "builtin_function", "builtin_core_function",
         "builtin_section", "operator", "identifier", "integer", "float", "string", "bracket", 
-        "punctuation", "preprocessor_text", "string_hash"
+        "punctuation", "preprocessor_text", "string_hash", "not_supported"
     };
 
     for (auto const& key : ideColors)

--- a/plugin/components/tokenizer.h
+++ b/plugin/components/tokenizer.h
@@ -28,6 +28,7 @@ class JSFXTokenizer : public juce::CPlusPlusCodeTokeniser
             tokenType_punctuation,
             tokenType_preprocessor,
             tokenType_string_hash,
+            tokenType_not_supported,
         };
 
     private:

--- a/plugin/components/tokenizer_functions.h
+++ b/plugin/components/tokenizer_functions.h
@@ -43,7 +43,7 @@ namespace JSFXTokenizerFunctions {
         }
 
         for (int i = 0; k[i] != nullptr; ++i)
-            if (token.compare(juce::CharPointer_ASCII(k[i])) == 0)
+            if (token.compareIgnoreCase(juce::CharPointer_ASCII(k[i])) == 0)
                 return true;
 
         return false;
@@ -81,7 +81,7 @@ namespace JSFXTokenizerFunctions {
         }
 
         for (int i = 0; k[i] != nullptr; ++i)
-            if (token.compare(juce::CharPointer_ASCII(k[i])) == 0)
+            if (token.compareIgnoreCase(juce::CharPointer_ASCII(k[i])) == 0)
                 return true;
 
         return false;
@@ -93,7 +93,7 @@ namespace JSFXTokenizerFunctions {
         static const char* const unsupported[] = {"export_buffer_to_project", "get_host_numchan", "set_host_numchan", "get_pin_mapping", "set_pin_mapping", "get_pinmapper_flags", "set_pinmapper_flags", "get_host_placement"};
         
         for (int i = 0; unsupported[i] != nullptr; ++i)
-            if (token.compare(juce::CharPointer_ASCII(unsupported[i])) == 0)
+            if (token.compareIgnoreCase(juce::CharPointer_ASCII(unsupported[i])) == 0)
                 return true;
         
         return false;
@@ -134,7 +134,7 @@ namespace JSFXTokenizerFunctions {
         }
 
         for (int i = 0; k[i] != nullptr; ++i)
-            if (token.compare(juce::CharPointer_ASCII(k[i])) == 0)
+            if (token.compareIgnoreCase(juce::CharPointer_ASCII(k[i])) == 0)
                 return true;
 
         return false;
@@ -175,7 +175,7 @@ namespace JSFXTokenizerFunctions {
         }
 
         for (int i = 0; k[i] != nullptr; ++i)
-            if (token.compare(juce::CharPointer_ASCII(k[i])) == 0)
+            if (token.compareIgnoreCase(juce::CharPointer_ASCII(k[i])) == 0)
                 return true;
 
         return false;

--- a/plugin/components/tokenizer_functions.h
+++ b/plugin/components/tokenizer_functions.h
@@ -87,6 +87,18 @@ namespace JSFXTokenizerFunctions {
         return false;
     }
 
+    static bool isNotSupported(juce::String::CharPointerType token, const int tokenLength) noexcept
+    {
+        (void) tokenLength;
+        static const char* const unsupported[] = {"export_buffer_to_project", "get_host_numchan", "set_host_numchan", "get_pin_mapping", "set_pin_mapping", "get_pinmapper_flags", "set_pinmapper_flags", "get_host_placement"};
+        
+        for (int i = 0; unsupported[i] != nullptr; ++i)
+            if (token.compare(juce::CharPointer_ASCII(unsupported[i])) == 0)
+                return true;
+        
+        return false;
+    }
+
     static bool isBuiltinFunction(juce::String::CharPointerType token, const int tokenLength) noexcept
     {
         static const char* const keywords2Char[] = { nullptr };
@@ -187,7 +199,7 @@ namespace JSFXTokenizerFunctions {
             ++tokenLength;
         }
 
-        if (tokenLength > 1 && tokenLength <= 16)
+        if (tokenLength > 1 && tokenLength <= 25)
         {
             possible.writeNull();
 
@@ -202,6 +214,9 @@ namespace JSFXTokenizerFunctions {
 
             if (JSFXTokenizerFunctions::isBuiltinFunction(juce::String::CharPointerType(possibleIdentifier), tokenLength))
                 return JSFXTokenizer::tokenType_builtin_function;
+
+            if (JSFXTokenizerFunctions::isNotSupported(juce::String::CharPointerType(possibleIdentifier), tokenLength))
+                return JSFXTokenizer::tokenType_not_supported;
         }
 
         return JSFXTokenizer::tokenType_identifier;

--- a/plugin/lookandfeel.cpp
+++ b/plugin/lookandfeel.cpp
@@ -44,7 +44,8 @@ std::map<std::string, std::array<uint8_t, 3>> getDefaultColors()
         {"bracket", std::array<uint8_t, 3>{192, 192, 255}},
         {"punctuation", std::array<uint8_t, 3>{0, 255, 255}},
         {"preprocessor_text", std::array<uint8_t, 3>{32, 192, 255}},
-        {"string_hash", std::array<uint8_t, 3>{192, 255, 128}}
+        {"string_hash", std::array<uint8_t, 3>{192, 255, 128}},
+        {"not_supported", std::array<uint8_t, 3>{255, 62, 62}}
     };
 }
 

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -23,6 +23,7 @@
 #include "ysfx_eel_utils.hpp"
 #include "ysfx_api_eel.hpp"
 #include "ysfx_preprocess.hpp"
+#include "ysfx_api_host_interaction_dummy.hpp"
 #include <type_traits>
 #include <algorithm>
 #include <functional>
@@ -72,6 +73,7 @@ ysfx_api_initializer::ysfx_api_initializer()
     ysfx_api_init_reaper();
     ysfx_api_init_file();
     ysfx_api_init_gfx();
+    ysfx_api_init_host_interaction();
 }
 
 ysfx_api_initializer::~ysfx_api_initializer()

--- a/sources/ysfx_api_host_interaction_dummy.hpp
+++ b/sources/ysfx_api_host_interaction_dummy.hpp
@@ -1,0 +1,72 @@
+// Copyright 2025 Joep Vanlier
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+#include "ysfx_eel_utils.hpp"
+
+static EEL_F NSEEL_CGEN_CALL export_buffer_to_project(void *, INT_PTR, EEL_F **)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL get_host_numchan(void *)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL get_pinmapper_flags(void *)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL set_host_numchan(void *, EEL_F *)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL set_pinmapper_flags(void *, EEL_F *)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL get_pin_mapping(void *, INT_PTR, EEL_F **)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL set_pin_mapping(void *, INT_PTR, EEL_F **)
+{
+    return 0;
+}
+
+static EEL_F NSEEL_CGEN_CALL get_host_placement(void *, INT_PTR, EEL_F **)
+{
+    return 0;
+}
+
+void ysfx_api_init_host_interaction()
+{
+    // Provide stubs so that these jsfx won't fail to compile completely
+    NSEEL_addfunc_varparm("export_buffer_to_project", 5, NSEEL_PProc_THIS, &export_buffer_to_project);
+    NSEEL_addfunc_retval("get_host_numchan", 1, NSEEL_PProc_THIS, &get_host_numchan);
+    NSEEL_addfunc_retval("set_host_numchan", 1, NSEEL_PProc_THIS, &set_host_numchan);
+    NSEEL_addfunc_exparms("get_pin_mapping", 4, NSEEL_PProc_THIS, &get_pin_mapping);
+    NSEEL_addfunc_exparms("set_pin_mapping", 5, NSEEL_PProc_THIS, &set_pin_mapping);
+    NSEEL_addfunc_retval("get_pinmapper_flags", 1, NSEEL_PProc_THIS, &get_pinmapper_flags);
+    NSEEL_addfunc_retval("set_pinmapper_flags", 1, NSEEL_PProc_THIS, &set_pinmapper_flags);
+    NSEEL_addfunc_varparm("get_host_placement", 0, NSEEL_PProc_THIS, &get_host_placement);
+}


### PR DESCRIPTION
Provide some stubs for host interaction functions we don't explicitly support, but which in most cases won't prevent a plugin from mostly working correctly.