### PR TITLE
preprocessor: parse `config` header

### DIFF
--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -423,7 +423,7 @@ void YsfxEditor::Impl::updateInfo()
         m_ideView->setStatusText(info->errors.getReference(0));
         juce::String errors = juce::String(TRANS("Error(s) parsing JSFX:\n"));
         for (auto i = 0; i < info->errors.size(); i++) {
-            errors += info->errors.getReference(0);
+            errors += info->errors.getReference(0) + std::string("\n");
         }
         m_lblError->setText(errors, juce::dontSendNotification);
     } else if (!info->warnings.isEmpty())

--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -37,6 +37,7 @@
 #include <cassert>
 #include <cmath>
 
+
 static_assert(std::is_same<EEL_F, ysfx_real>::value,
               "ysfx_real is incorrectly defined");
 
@@ -253,7 +254,10 @@ bool ysfx_load_file(ysfx_t *fx, const char *filepath, uint32_t loadopts)
                 ysfx_logf(*fx->config, ysfx_log_error, "%s:%u: %s", ysfx::path_file_name(filepath).c_str(), error.line + 1, error.message.c_str());
                 return false;
             }
-            ysfx_parse_header(main->toplevel.header.get(), main->header);
+            if (!ysfx_parse_header(main->toplevel.header.get(), main->header, &error)) {
+                ysfx_logf(*fx->config, ysfx_log_error, "%s:%u: %s", ysfx::path_file_name(filepath).c_str(), error.line + 1, error.message.c_str());
+                return false;
+            };
 
             for (auto config_item : main->header.config_items) {
                 preprocessor_values[config_item.identifier] = config_item.default_value;  // Load preprocessor defaults
@@ -373,7 +377,10 @@ bool ysfx_load_file(ysfx_t *fx, const char *filepath, uint32_t loadopts)
                 ysfx_logf(*fx->config, ysfx_log_error, "%s:%u: %s", ysfx::path_file_name(imported_path.c_str()).c_str(), error.line + 1, error.message.c_str());
                 return false;
             }
-            ysfx_parse_header(unit->toplevel.header.get(), unit->header);
+            if (!ysfx_parse_header(unit->toplevel.header.get(), unit->header, &error)) {
+                ysfx_logf(*fx->config, ysfx_log_error, "%s:%u: %s", ysfx::path_file_name(imported_path.c_str()).c_str(), error.line + 1, error.message.c_str());
+                return false;
+            }
 
             // process the imported dependencies, *first*
             for (const std::string &name : unit->header.imports) {

--- a/sources/ysfx_parse.hpp
+++ b/sources/ysfx_parse.hpp
@@ -120,6 +120,6 @@ struct ysfx_parsed_filename_t {
 bool ysfx_parse_toplevel(ysfx::text_reader &reader, ysfx_toplevel_t &toplevel, ysfx_parse_error *error, bool onlyHeader);
 bool ysfx_parse_slider(const char *line, ysfx_slider_t &slider);
 bool ysfx_parse_filename(const char *line, ysfx_parsed_filename_t &filename);
-void ysfx_parse_header(ysfx_section_t *section, ysfx_header_t &header);
+bool ysfx_parse_header(ysfx_section_t *section, ysfx_header_t &header, ysfx_parse_error *error);
 ysfx_config_item ysfx_parse_config_line(const char *rest);
 bool ysfx_config_item_is_valid(const ysfx_config_item& item);

--- a/sources/ysfx_parse.hpp
+++ b/sources/ysfx_parse.hpp
@@ -90,6 +90,14 @@ struct ysfx_options_t {
     uint32_t gfx_hz = 30;
 };
 
+struct ysfx_config_item {
+    std::string identifier;
+    std::string name;
+    ysfx_real default_value{0};
+    ysfx::string_list var_names{};
+    std::vector<ysfx_real> var_values{};
+};
+
 struct ysfx_header_t {
     std::string desc;
     std::string author;
@@ -101,6 +109,7 @@ struct ysfx_header_t {
     ysfx::string_list filenames;
     ysfx_options_t options;
     ysfx_slider_t sliders[ysfx_max_sliders];
+    std::vector<ysfx_config_item> config_items;
 };
 
 struct ysfx_parsed_filename_t {
@@ -108,7 +117,9 @@ struct ysfx_parsed_filename_t {
     std::string filename;
 };
 
-bool ysfx_parse_toplevel(ysfx::text_reader &reader, ysfx_toplevel_t &toplevel, ysfx_parse_error *error);
+bool ysfx_parse_toplevel(ysfx::text_reader &reader, ysfx_toplevel_t &toplevel, ysfx_parse_error *error, bool onlyHeader);
 bool ysfx_parse_slider(const char *line, ysfx_slider_t &slider);
 bool ysfx_parse_filename(const char *line, ysfx_parsed_filename_t &filename);
 void ysfx_parse_header(ysfx_section_t *section, ysfx_header_t &header);
+ysfx_config_item ysfx_parse_config_line(const char *rest);
+bool ysfx_config_item_is_valid(const ysfx_config_item& item);

--- a/sources/ysfx_preprocess.cpp
+++ b/sources/ysfx_preprocess.cpp
@@ -17,6 +17,7 @@
 
 #include "ysfx.hpp"
 #include "ysfx_utils.hpp"
+#include <map>
 
 #include "WDL/ptrlist.h"
 #include "WDL/assocarray.h"
@@ -26,7 +27,7 @@
 #include "WDL/eel2/eel_pproc.h"
 
 
-bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str)
+bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str, std::map<std::string, ysfx_real> preprocessor_values)
 {
     std::string line;
     line.reserve(256);
@@ -39,6 +40,11 @@ bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::st
     }
 
     EEL2_PreProcessor pproc;
+
+    for (auto it = preprocessor_values.begin(); it != preprocessor_values.end(); ++it) {
+        pproc.define(it->first.c_str(), it->second);
+    }
+
     const char *err = pproc.preprocess(file_str.Get(), &pp_str);
     if (err) {
         error->line = 0;

--- a/sources/ysfx_preprocess.hpp
+++ b/sources/ysfx_preprocess.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "ysfx.h"
 #include <string>
+#include <map>
 
-bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str);
+bool ysfx_preprocess(ysfx::text_reader &reader, ysfx_parse_error *error, std::string& in_str, std::map<std::string, ysfx_real> preprocessor_values);

--- a/sources/ysfx_reader.cpp
+++ b/sources/ysfx_reader.cpp
@@ -65,6 +65,11 @@ char string_text_reader::peek_next_char()
     return *ptr;
 }
 
+void string_text_reader::rewind()
+{
+    m_char_ptr = m_char_start;
+}
+
 //------------------------------------------------------------------------------
 char stdio_text_reader::read_next_char()
 {
@@ -93,6 +98,13 @@ char stdio_text_reader::peek_next_char()
 
     ungetc(next, stream);
     return (unsigned char)next;
+}
+
+void stdio_text_reader::rewind()
+{
+    FILE *stream = m_stream;
+
+    fseek(stream, 0, SEEK_SET);
 }
 
 } // namespace ysfx

--- a/sources/ysfx_reader.hpp
+++ b/sources/ysfx_reader.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~text_reader() = default;
     virtual char read_next_char() = 0;
     virtual char peek_next_char() = 0;
+    virtual void rewind() = 0;
     bool read_next_line(std::string &line);
 };
 
@@ -35,11 +36,13 @@ public:
 class string_text_reader : public text_reader
 {
 public:
-    explicit string_text_reader(const char *text) : m_char_ptr(text) {}
+    explicit string_text_reader(const char *text) : m_char_ptr(text), m_char_start(text) {}
     char read_next_char() override;
     char peek_next_char() override;
+    void rewind() override;
 private:
     const char *m_char_ptr = nullptr;
+    const char *m_char_start = nullptr;
 };
 
 //------------------------------------------------------------------------------
@@ -49,6 +52,7 @@ public:
     explicit stdio_text_reader(FILE *stream) : m_stream(stream) {}
     char read_next_char() override;
     char peek_next_char() override;
+    void rewind() override;
 private:
     FILE *m_stream = nullptr;
 };

--- a/tests/ysfx_test_integration.cpp
+++ b/tests/ysfx_test_integration.cpp
@@ -180,6 +180,23 @@ TEST_CASE("integration", "[integration]")
         REQUIRE(ysfx_read_var(fx.get(), "x3") == 8);
     };
 
+    SECTION("preprocessor config duplicate variable")
+    {
+        const char *text =
+            "desc:test" "\n"
+            "config:test1 \"test\" 8 1=test 2" "\n"
+            "config: tESt1 \"test2\" 3 1 2" "\n"
+            "@init";
+        
+        scoped_new_dir dir_fx("${root}/Effects");
+        scoped_new_txt file_main("${root}/Effects/example.jsfx", text);
+
+        ysfx_config_u config{ysfx_config_new()};
+        ysfx_u fx{ysfx_new(config.get())};
+
+        REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0) == false);
+    };    
+
     SECTION("gfx_hz")
     {
         auto compile_and_check = [](const char *text, uint32_t ref_value) {

--- a/tests/ysfx_test_parse.cpp
+++ b/tests/ysfx_test_parse.cpp
@@ -756,7 +756,7 @@ TEST_CASE("header parsing", "[parse]")
         section.text.assign(text);
 
         ysfx_header_t header;
-        ysfx_parse_header(&section, header);
+        ysfx_parse_header(&section, header, nullptr);
         REQUIRE(header.desc == "The desc");
         REQUIRE(header.in_pins.size() == 2);
         REQUIRE(header.in_pins[0] == "The input 1");
@@ -780,7 +780,7 @@ TEST_CASE("header parsing", "[parse]")
         section.text.assign(text);
 
         ysfx_header_t header;
-        ysfx_parse_header(&section, header);
+        ysfx_parse_header(&section, header, nullptr);
         REQUIRE(header.in_pins.empty());
         REQUIRE(header.out_pins.empty());
     }
@@ -796,7 +796,7 @@ TEST_CASE("header parsing", "[parse]")
         section.text.assign(text);
 
         ysfx_header_t header;
-        ysfx_parse_header(&section, header);
+        ysfx_parse_header(&section, header, nullptr);
         REQUIRE(header.in_pins.empty());
         REQUIRE(header.out_pins.empty());
     }
@@ -814,7 +814,7 @@ TEST_CASE("header parsing", "[parse]")
         section.text.assign(text);
 
         ysfx_header_t header;
-        ysfx_parse_header(&section, header);
+        ysfx_parse_header(&section, header, nullptr);
         REQUIRE(header.in_pins.size() == 2);
         REQUIRE(header.in_pins[0] == "none");
         REQUIRE(header.in_pins[1] == "Input");
@@ -875,7 +875,7 @@ TEST_CASE("header parsing", "[parse]")
         section.text.assign(text);
 
         ysfx_header_t header;
-        ysfx_parse_header(&section, header);
+        ysfx_parse_header(&section, header, nullptr);
         REQUIRE(header.filenames.size() == 3);
         REQUIRE(header.filenames[0] == "toto");
         REQUIRE(header.filenames[1] == "titi");
@@ -894,7 +894,7 @@ TEST_CASE("header parsing", "[parse]")
         section.text.assign(text);
 
         ysfx_header_t header;
-        ysfx_parse_header(&section, header);
+        ysfx_parse_header(&section, header, nullptr);
         REQUIRE(header.filenames.size() == 2);
         REQUIRE(header.filenames[0] == "toto");
         REQUIRE(header.filenames[1] == "titi");


### PR DESCRIPTION
The main file in a JSFX plugin can contain some header information that provides options and defaults for variables that should be defined in the pre-processor. This PR adds the first chunk of support for that. Right now, only using the defaults is supported.