### PR TITLE
ysfx: fix crash on calling gfx functions on different thread when no framebuffer exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             artifacts: yes
           - name: linux64
             display-name: Linux 64-bit
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
             platform: x86_64
             release-arch: Linux64
             os-type: Linux

--- a/sources/ysfx_api_gfx_lice.hpp
+++ b/sources/ysfx_api_gfx_lice.hpp
@@ -4,6 +4,7 @@
 //
 //------------------------------------------------------------------------------
 //
+// Copyright (C) 2025 and later Joep Vanlier
 // Copyright (C) 2021 and later Jean Pierre Cimalando
 // Copyright (C) 2005 and later Cockos Incorporated
 //
@@ -44,11 +45,20 @@
 #   include "ysfx_api_gfx.cpp"
 #endif
 
-#define EEL_LICE_GET_CONTEXT(opaque) ((opaque) ? ((ysfx_t *)(opaque))->gfx.state->lice.get() : nullptr)
+#define EEL_LICE_GET_CONTEXT(opaque) ((opaque) ? ysfx_get_lice_context((ysfx_t *)(opaque)) : nullptr)
 
 //------------------------------------------------------------------------------
 
 #define LICE_FUNCTION_VALID(x) (sizeof(int) > 0)
+
+static eel_lice_state *ysfx_get_lice_context(ysfx_t *fx)
+{
+    auto gfx_state = ysfx_gfx_get_context(fx);  /* Returns null if not @gfx thread */
+    if (!gfx_state)
+        return nullptr;
+
+    return gfx_state->lice.get();
+}
 
 static HDC LICE__GetDC(LICE_IBitmap *bm)
 {


### PR DESCRIPTION
This PR blocks calls to lice functions from threads other than the graphics thread.

This fixes a crash bug that can occur in the plugin when a call is made to write to the framebuffer from @init, which in the plugin isn't guaranteed to be valid at all times. This can happen when a user closes the gfx window of a plugin; then changes the routing (as this triggers @init) in a plugin that writes to the framebuffer from its initialization function.

While this doesn't directly solve the issue at hand (checking framebuffer validity); it seems prudent to make sure that these calls only happen from the graphics thread regardless as the lice functions are likely not thread safe.

Long term, I want to see if we can improve the API such that a valid framebuffer is always guaranteed, but I don't want to rush into that, hence this hotfix.