### PR TITLE
ysfx: allow customizing the stay on top behavior of the plugin

### DIFF
--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -94,6 +94,32 @@ struct YsfxEditor::Impl {
     class SubWindow : public juce::DocumentWindow {
     public:
         using juce::DocumentWindow::DocumentWindow;
+        SubWindow(const juce::String& name, juce::Colour backgroundColour, int requiredButtons, bool addToDesktop = true): DocumentWindow (name, backgroundColour, requiredButtons, addToDesktop)
+        {
+            juce::Timer *timer = FunctionalTimer::create(
+                [this]() {
+                    if (juce::Process::isForegroundProcess()) {
+                        if (isVisible() && !isAlwaysOnTop()) {
+                            setAlwaysOnTop(true);
+                        }
+                    } else {
+                        if (isAlwaysOnTop()) {
+                            setAlwaysOnTop(false);
+
+                            // Questionable windows fix
+                            auto oldFlags = this->getPeer()->getStyleFlags();
+                            removeFromDesktop();
+                            this->addToDesktop(oldFlags);
+                        }
+                    }
+                }
+            );
+            m_stayOnTopTimer.reset(timer);
+            m_stayOnTopTimer->startTimer(50);
+        }
+
+    private:
+        std::unique_ptr<juce::Timer> m_stayOnTopTimer;
 
     protected:
         void closeButtonPressed() override { setVisible(false); }
@@ -821,7 +847,6 @@ void YsfxEditor::Impl::openCodeEditor()
 
     m_codeWindow->setVisible(true);
     m_codeWindow->toFront(true);
-    m_codeWindow->setAlwaysOnTop(true);
     m_ideView->focusOnCodeEditor();
 }
 

--- a/plugin/editor.h
+++ b/plugin/editor.h
@@ -20,6 +20,8 @@
 #include <memory>
 class YsfxProcessor;
 
+enum WindowBehaviour {alwaysOnTop = 0, normal = 1, dynamicOnTop = 2};
+
 class YsfxEditor : public juce::AudioProcessorEditor, public juce::FileDragAndDropTarget {
 public:
     explicit YsfxEditor(YsfxProcessor &proc);


### PR DESCRIPTION
Exposes a config flag in the theme.json for changing the stay on top behaviour.

The field is called `ysfx_sub_window_stay_on_top` and the integer values for the different options are:
0: alwaysOnTop
1: no alwaysOnTop
2: dynamic always on top
