### PR TITLE
tokenizer: fix missing sentinel value

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{matrix.artifacts == 'yes'}} && {{matrix.os-type != 'MinGW'}}
         with:
-          name: ${{matrix.display-name}} VST3
+          name: YSFX ${{matrix.display-name}} VST3
           path: |
             ${{runner.workspace}}/VST3/*
             ${{runner.workspace}}/LICENSE
@@ -188,7 +188,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{matrix.artifacts == 'yes'}} && {{matrix.os-type != 'MinGW'}}
         with:
-          name: ${{matrix.display-name}} CLAP
+          name: YSFX ${{matrix.display-name}} CLAP
           path: |
             ${{runner.workspace}}/CLAP/*
             ${{runner.workspace}}/LICENSE
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{matrix.os-type == 'macOS' && matrix.artifacts == 'yes'}}
         with:
-          name: ${{matrix.display-name}} AU
+          name: YSFX ${{matrix.display-name}} AU
           path: |
             ${{runner.workspace}}/AU/*
             ${{runner.workspace}}/LICENSE

--- a/plugin/components/tokenizer_functions.h
+++ b/plugin/components/tokenizer_functions.h
@@ -90,7 +90,7 @@ namespace JSFXTokenizerFunctions {
     static bool isNotSupported(juce::String::CharPointerType token, const int tokenLength) noexcept
     {
         (void) tokenLength;
-        static const char* const unsupported[] = {"export_buffer_to_project", "get_host_numchan", "set_host_numchan", "get_pin_mapping", "set_pin_mapping", "get_pinmapper_flags", "set_pinmapper_flags", "get_host_placement"};
+        static const char* const unsupported[] = {"export_buffer_to_project", "get_host_numchan", "set_host_numchan", "get_pin_mapping", "set_pin_mapping", "get_pinmapper_flags", "set_pinmapper_flags", "get_host_placement", nullptr};
         
         for (int i = 0; unsupported[i] != nullptr; ++i)
             if (token.compareIgnoreCase(juce::CharPointer_ASCII(unsupported[i])) == 0)


### PR DESCRIPTION
**Why this PR?**
This is a crash bug.

Note:
The mingw builds are failing, which seems to be due to changes in `stat`. This requires additional investigation, but I don't want to block a hotfix release for this segfault by it.