### PR TITLE
plugin: add a few accessibility options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ This contains a hosting library, providing a JSFX compiler and runtime.
 In addition, there is an audio plugin which can act as a JSFX host in a digital
 audio workstation.
 
+## Installation
+
+Installation should be as easy as dropping the plugin into your VST3, AU or CLAP
+folder. 
+
+#### Windows
+
+First install the MSVC redistributable.
+
+You can download the 64-bit version here: https://aka.ms/vs/17/release/vc_redist.x64.exe
+And the 32 bit version here: https://aka.ms/vs/17/release/vc_redist.x86.exe
+
+Note that the plugin may crash if you have an outdated version of the MSVC
+redistributable on your system.
+
+#### macOS
+
+Binaries are not signed. That means you have to explicitly allow it to be 
+run (since it is not from an identified developer). Usually it involves invoking:
+
+  `xattr -dr com.apple.quarantine /Path/To/Plugin/VST3/ysfx-s FX.vst3`
+  `xattr -dr com.apple.quarantine /Path/To/Plugin/VST3/ysfx-s instrument.vst3`
+
+Where you should fill in the path where the plugin is located on your system.
+
 # Helping out
 
 The best way to help out is by using the plugin and reporting bugs you run into. 

--- a/plugin/components/graphics_view.cpp
+++ b/plugin/components/graphics_view.cpp
@@ -304,9 +304,23 @@ void YsfxGraphicsView::resized()
         m_impl->m_gfxDirty = true;
 }
 
+void YsfxGraphicsView::setAccessibilityShortcuts(bool accessibilityShortcuts)
+{
+    m_accessibilityShortcuts = accessibilityShortcuts;
+}
+
 bool YsfxGraphicsView::keyPressed(const juce::KeyPress &key)
 {
     m_impl->updateYsfxKeyModifiers();
+
+    // Special keys must bubble up to the main component immediately
+    if (m_accessibilityShortcuts) {
+        if (key.getModifiers().isAltDown()) {
+            if (key.getKeyCode() == 'n' || key.getKeyCode() == 'N' || key.getKeyCode() == 'p' || key.getKeyCode() == 'P') {
+                return false;
+            }
+        }
+    }
 
     for (const Impl::KeyPressed &kp : m_impl->m_keysPressed) {
         if (kp.jcode == key.getKeyCode())

--- a/plugin/components/graphics_view.h
+++ b/plugin/components/graphics_view.h
@@ -28,6 +28,7 @@ public:
     void setScaling(float new_scaling);
     float getScaling();
     float getTotalScaling();
+    void setAccessibilityShortcuts(bool accessibilityShortcuts);
 
 protected:
     void paint(juce::Graphics &g) override;
@@ -48,6 +49,7 @@ private:
     std::atomic<float> m_pixelFactor{1.0f};
     std::atomic<float> m_outputScalingFactor{1.0f};
     bool fullPixelScaling{true};
+    bool m_accessibilityShortcuts{false};
 
     struct Impl;
     std::unique_ptr<Impl> m_impl;

--- a/plugin/components/parameters_panel.cpp
+++ b/plugin/components/parameters_panel.cpp
@@ -419,6 +419,9 @@ public:
     {
         parameterName.setText(parameter.getSliderName(), juce::dontSendNotification);
         parameterName.setJustificationType(juce::Justification::centredRight);
+        // Helps accessibility users because the name of the parameter is read out when
+        // tabbing over it.
+        parameterName.setWantsKeyboardFocus(true);
         addAndMakeVisible(parameterName);
         addAndMakeVisible(*(parameterComp = createParameterComp()));
 

--- a/plugin/components/searchable_popup.h
+++ b/plugin/components/searchable_popup.h
@@ -224,11 +224,11 @@
                     editor.setText (initial_string, juce::dontSendNotification);
 
                     editor.addKeyListener (this);
-                    editor.setAccessible (false); // no need to hear voiceover spelling each letter..
+                    editor.setAccessible (true); // no need to hear voiceover spelling each letter..
 
                     // startTimer (100); // will grab the keyboard focus for the texteditor.
 
-                    updateContent();
+                    updateContent(false);
                 }
                 
                 juce::Rectangle<int> getTargetScreenArea() {
@@ -377,7 +377,7 @@
                     }
                 }
 
-                void updateContent()
+                void updateContent(bool textChanged)
                 {
                     updateMatches();
 
@@ -434,12 +434,10 @@
 
                     if (highlighted_match < nb_visible_matches)
                     {
-#if JUCE_ACCESSIBILITY_FEATURES
-#ifndef TARGET_WIN32 // ca marche meme qd narrator n'est pas active sous win. J'ai reporte le bug a JUCE
-                        juce::AccessibilityHandler::postAnnouncement(quick_search_items.at (matches.at (highlighted_match)).label,
-                                                                     juce::AccessibilityHandler::AnnouncementPriority::medium);
-#endif
-#endif
+                        if (!textChanged) {
+                            juce::AccessibilityHandler::postAnnouncement(quick_search_items.at (matches.at (highlighted_match)).label,
+                                                                        juce::AccessibilityHandler::AnnouncementPriority::medium);
+                        }
                     }
                 }
 
@@ -548,7 +546,7 @@
 
                 void textEditorEscapeKeyPressed (juce::TextEditor&) override { m_owner->quickSearchFinished (0); }
 
-                void textEditorTextChanged (juce::TextEditor&) override { updateContent(); }
+                void textEditorTextChanged (juce::TextEditor&) override { updateContent(true); }
 
                 // just to silence a clang warning about the other overriden keyPressed member function
                 bool keyPressed (const juce::KeyPress& key) override { return juce::Component::keyPressed (key); }
@@ -572,7 +570,7 @@
                             --highlighted_match;
                             if (first_displayed_match > highlighted_match)
                                 first_displayed_match = highlighted_match;
-                            updateContent();
+                            updateContent(false);
                         }
                         return true;
                     }
@@ -590,7 +588,7 @@
                             auto& q = quick_search_items.at (matches.at(static_cast<size_t>(highlighted_match)));
                             if (! q.popup_menu_item->isEnabled)
                                 highlighted_match = 0;
-                            updateContent();
+                            updateContent(false);
                         }
                         return true;
                     }

--- a/plugin/components/searchable_popup.h
+++ b/plugin/components/searchable_popup.h
@@ -130,6 +130,8 @@
                     {
                         if (new_e.popup_menu_item != e.popup_menu_item || m_highlighted != new_highlighted)
                         {
+                            setAccessible(true);
+                            setTitle(new_e.label);
                             this->e = new_e;
                             this->m_highlighted = new_highlighted;
                             repaint();

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -170,6 +170,8 @@ struct YsfxEditor::Impl {
     std::unique_ptr<SubWindow> m_presetWindow;
     std::unique_ptr<juce::TooltipWindow> m_tooltipWindow;
 
+    juce::String m_lastReadPreset{""};
+
     //==========================================================================
     void createUI();
     void connectUI();
@@ -405,6 +407,11 @@ void YsfxEditor::Impl::grabInfoAndUpdate()
     
     m_lblFilePath->setText(getLabel(), juce::dontSendNotification);
     
+    if (m_lastReadPreset.compare(m_currentPresetInfo->m_lastChosenPreset)) {
+        m_lastReadPreset = m_currentPresetInfo->m_lastChosenPreset;
+        juce::AccessibilityHandler::postAnnouncement(m_lastReadPreset, juce::AccessibilityHandler::AnnouncementPriority::medium);
+    }
+
     if ((m_proc->retryLoad() == RetryState::mustRetry) && !m_fileChooserActive) {
         chooseFileAndLoad();
         m_btnLoadFile->setButtonText(TRANS("Locate"));

--- a/plugin/editor.h
+++ b/plugin/editor.h
@@ -36,6 +36,7 @@ protected:
 
 private:
     void readTheme();
+    bool keyPressed(const juce::KeyPress& k) override;
 
     int m_headerSize{45};
     struct Impl;


### PR DESCRIPTION
Adds two small features that improve accessibility for people using `ysfx` with a screen reader:

- When the filter is engaged and the user scrolls through the list of presets, the OS is notified of the selected item's name.
- Add the option to use `ALT + N` and `ALT + P` to scroll through the presets. These shortcuts can be enabled/disabled in the preset option menu (next to `Presets`).
- When a preset is selected, the name is presented to any screen narrator active.
- Make sure the slider label can be selected such that it can be heard when screen narration is active.
- Add keyboard controls for sliders. Up/Down/Left/Right arrow for changing the value. Ctrl, Cmd and Shift modifiers to make larger adjustments. Page up and down for even larger adjustments and home and end to skip to the start and end.