### PR TITLE
plugin: handle `play_state` stop vs pause

### DIFF
--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -286,7 +286,7 @@ YSFX_API void ysfx_get_pdc_channels(ysfx_t *fx, uint32_t channels[2]);
 YSFX_API bool ysfx_get_pdc_midi(ysfx_t *fx);
 
 typedef enum ysfx_playback_state_e {
-    ysfx_playback_error = 0,
+    ysfx_playback_stopped = 0,
     ysfx_playback_playing = 1,
     ysfx_playback_paused = 2,
     ysfx_playback_recording = 5,


### PR DESCRIPTION
Fixed bug in `play_state`. Going forward, `play_state` set to `0` signifies that playback is stopped rather than an error (analogously to JSFX). It is also different from `play_state` set to `2` which indicates that transport is paused. Note that this involves a small breaking change in the JSFX enumeration.