### PR TITLE
plugin: add version information / better tooltips

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 
 cmake_minimum_required(VERSION 3.15)
-project(ysfx VERSION "0.0.0" LANGUAGES C CXX ASM)
+project(ysfx VERSION "0.0.41" LANGUAGES C CXX ASM)
 
 # check if we are building from this project, or are imported by another
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/cmake.plugin.txt
+++ b/cmake.plugin.txt
@@ -115,6 +115,7 @@ function(add_new_target target_name is_synth)
 
     target_compile_definitions("${target_name}"
     PUBLIC
+        VERSION_STRING="${PROJECT_VERSION}"
         "JUCE_WEB_BROWSER=0"
         "JUCE_USE_CURL=0"
         "JUCE_VST3_CAN_REPLACE_VST2=0")


### PR DESCRIPTION
- plugin: added version information (visible in the label before any plugin is loaded)
- plugin: added version information to tooltip for loaded plugins
- plugin: added tooltips for all the top level controls that did not yet have any
- plugin: improved splitting of plugin path name in plugin name tooltip