### PR TITLE
plugin: trigger `resized()` after param panel init

### DIFF
--- a/plugin/components/parameters_panel.cpp
+++ b/plugin/components/parameters_panel.cpp
@@ -572,6 +572,7 @@ void YsfxParametersPanel::setParametersDisplayed(const juce::Array<YsfxParameter
     }
 
     setSize(maxWidth, getRecommendedHeight());
+    resized();
 }
 
 int YsfxParametersPanel::getRecommendedHeight(int heightAtLeast) const


### PR DESCRIPTION
- Fixed issue where the parameter panel did not scale appropriately in situations where the panel never got resized after construction