### PR TITLE
presets: also load them if they end only with .rpl

### DIFF
--- a/sources/ysfx.cpp
+++ b/sources/ysfx.cpp
@@ -313,10 +313,23 @@ bool ysfx_load_file(ysfx_t *fx, const char *filepath, uint32_t loadopts)
         fx->source.main_file_path.assign(filepath);
 
         // find the bank file, if present
-        ysfx::case_resolve(
-            ysfx::path_directory(filepath).c_str(),
-            (ysfx::path_file_name(filepath) + ".rpl").c_str(),
-            fx->source.bank_path);
+        const auto directory = ysfx::path_directory(filepath);
+        auto filename = ysfx::path_file_name(filepath);
+        int found_bank = ysfx::case_resolve(directory.c_str(),
+                                            (filename + ".rpl").c_str(),
+                                            fx->source.bank_path);
+        if (found_bank == 0) {
+            if (filename.length() > 5) {
+                std::string ext = filename.substr(filename.length() - 5, 5);
+                std::transform(ext.begin(), ext.end(), ext.begin(), ysfx::ascii_tolower);
+                if (ext == ".jsfx") {
+                    filename = filename.substr(0, filename.length() - 5);
+                    ysfx::case_resolve(directory.c_str(),
+                                       (filename + ".rpl").c_str(),
+                                       fx->source.bank_path);
+                }
+            }
+        }
 
         // fill the file enums with the contents of directories
         ysfx_fill_file_enums(fx);

--- a/tests/ysfx_test_preset.cpp
+++ b/tests/ysfx_test_preset.cpp
@@ -295,6 +295,14 @@ TEST_CASE("preset handling", "[preset]")
             ysfx_unload(fx.get());
             REQUIRE(ysfx_get_bank_path(fx.get()) == std::string());
         }
+
+        {
+            scoped_new_txt file_rpl("${root}/Effects/example.RpL", "");
+            REQUIRE(ysfx_load_file(fx.get(), file_main.m_path.c_str(), 0));
+            REQUIRE(!ysfx::ascii_casecmp(ysfx_get_bank_path(fx.get()), file_rpl.m_path.c_str()));
+            ysfx_unload(fx.get());
+            REQUIRE(ysfx_get_bank_path(fx.get()) == std::string());
+        }
     }
 
     SECTION("Newer RPL Bank")


### PR DESCRIPTION
Right now the code was loading only `<plugin>.jsfx.rpl` files. But a fair amount of files around the internets have their presets as `<plugin>.rpl` and they weren't being found