### PR TITLE
ysfx: let host control `gfx_w` and `gfx_h` size

### DIFF
--- a/sources/ysfx_api_gfx.cpp
+++ b/sources/ysfx_api_gfx.cpp
@@ -397,8 +397,6 @@ void ysfx_gfx_prepare(ysfx_t *fx)
     ysfx_real gfx_w = (ysfx_real)lice->m_framebuffer->getWidth();
     ysfx_real gfx_h = (ysfx_real)lice->m_framebuffer->getHeight();
     if (state->scale > 1.0) {
-        gfx_w *= state->scale;
-        gfx_h *= state->scale;
         *fx->var.gfx_ext_retina = state->scale;
     }
     *fx->var.gfx_w = gfx_w;


### PR DESCRIPTION
#### Why this PR?

Prior to this change, setting the scale factor would increase `gfx_w` and `gfx_h`, but not the actual canvas size it was drawing to.

Ideally, the canvas size should just be set by the host, and the scaling hint should propagate into the JSFX, but not modify `gfx_w` and `gfx_h`.

Note that the host [should double the canvas size on macs with retina](https://www.reaper.fm/sdk/js/gfx.php#gfx_ext_retina), but leave it unmodified on other OSes, according to the JSFX spec (I will save this for a future PR).