### PR TITLE
Preset manager features for jsfx without rpl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 
 cmake_minimum_required(VERSION 3.15)
-project(ysfx VERSION "0.0.41" LANGUAGES C CXX ASM)
+project(ysfx VERSION "0.0.44" LANGUAGES C CXX ASM)
 
 # check if we are building from this project, or are imported by another
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/exports/ysfx.txt
+++ b/exports/ysfx.txt
@@ -95,6 +95,7 @@ ysfx_add_preset_to_bank
 ysfx_preset_exists
 ysfx_delete_preset_from_bank
 ysfx_rename_preset_from_bank
+ysfx_swap_preset_in_bank
 ysfx_enum_vars
 ysfx_find_var
 ysfx_read_var

--- a/include/ysfx.h
+++ b/include/ysfx.h
@@ -418,6 +418,8 @@ YSFX_API uint32_t ysfx_preset_exists(ysfx_bank_t *bank_in, const char* preset_na
 YSFX_API ysfx_bank_t *ysfx_delete_preset_from_bank(ysfx_bank_t *bank_in, const char* preset_name);
 // renames a preset from the bank and returns a *new* bank without freeing the old bank
 YSFX_API ysfx_bank_t *ysfx_rename_preset_from_bank(ysfx_bank_t *bank_in, const char* preset_name, const char* new_preset_name);
+// swaps two presets in a bank (swaps in place!)
+YSFX_API void ysfx_swap_preset_in_bank(ysfx_bank_t *bank, int32_t preset_idx_1, int32_t preset_idx_2);
 
 // type of a function which can enumerate VM variables; returning 0 ends the search
 typedef int (ysfx_enum_vars_callback_t)(const char *name, ysfx_real *var, void *userdata);

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -142,6 +142,11 @@ class BankItemsListBoxModel final : public juce::ListBox, public juce::ListBoxMo
             m_dblClickCallback(row);
         }
 
+        void returnKeyPressed (int lastRowSelected) override
+        {
+            m_dblClickCallback(lastRowSelected);
+        }
+
         void listBoxItemClicked(int row, const juce::MouseEvent& evnt) override
         {
             if (evnt.mods.isRightButtonDown() && m_renameCallback) {

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -397,16 +397,16 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
             if (withClose) {
                 m_btnCloseFile.reset(new juce::TextButton());
                 m_btnCloseFile->onClick = [this]() { closeFile(); };
-                m_btnCloseFile->setButtonText(TRANS("Close"));
-                m_btnCloseFile->setTooltip(TRANS("Close RPL file"));
+                m_btnCloseFile->setButtonText(TRANS("Clear"));
+                m_btnCloseFile->setTooltip(TRANS("Close RPL file and clear preset list"));
                 addAndMakeVisible(*m_btnCloseFile);
             }
 
             m_movePresetUp.reset(new juce::TextButton());
-            m_movePresetUp->setButtonText(TRANS("Up"));
+            m_movePresetUp->setButtonText(TRANS("Move up"));
             m_movePresetUp->setTooltip(TRANS("Move preset up"));
             addAndMakeVisible(*m_movePresetUp);
-
+            
             m_movePresetUp->onClick = [this]() {
                 if (m_listBox->getSelectedRow() > 0 && getBank()) {
                     ysfx_swap_preset_in_bank(m_bank.get(), m_listBox->getSelectedRow() - 1, m_listBox->getSelectedRow());
@@ -416,7 +416,7 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
             };
             
             m_movePresetDown.reset(new juce::TextButton());
-            m_movePresetDown->setButtonText(TRANS("Down"));
+            m_movePresetDown->setButtonText(TRANS("Move down"));
             m_movePresetDown->setTooltip(TRANS("Move preset down"));
             addAndMakeVisible(*m_movePresetDown);
             

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -243,6 +243,7 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
             ysfx_bank_shared src_bank = loadedBank->getBank();
             if (!src_bank) return;
 
+            std::reverse(indices.begin(), indices.end());
             transferPresetRecursive(indices, src_bank, false);
         }
 

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -172,6 +172,7 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
         juce::File m_file;
         ysfx_bank_shared m_bank;
         int m_useNativeFilePicker{1};
+        bool m_alignLeft{false};
 
         std::unique_ptr<juce::AlertWindow> m_editDialog;
         std::unique_ptr<BankItemsListBoxModel> m_listBox;
@@ -203,10 +204,15 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
             auto bottomRow = temp.removeFromBottom(30);
 
             if (m_btnCloseFile) {
-                m_btnCloseFile->setBounds(bottomRow.removeFromRight(60));
+                m_btnCloseFile->setBounds(bottomRow.removeFromRight(80));
             }
-            m_movePresetDown->setBounds(bottomRow.removeFromRight(60));
-            m_movePresetUp->setBounds(bottomRow.removeFromRight(60));
+            if (m_alignLeft) {
+                m_movePresetDown->setBounds(bottomRow.removeFromLeft(80));
+                m_movePresetUp->setBounds(bottomRow.removeFromLeft(80));
+            } else {
+                m_movePresetDown->setBounds(bottomRow.removeFromRight(80));
+                m_movePresetUp->setBounds(bottomRow.removeFromRight(80));
+            }
 
             if (m_fileLock) {    
                 m_fileLock->setButtonText(TRANS("Allow modification"));
@@ -383,8 +389,10 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
             m_movePresetDown->setEnabled(false);
         }
 
-        void createUI(bool withLoad, bool withModificationProtection, bool withClose)
+        void createUI(bool withLoad, bool withModificationProtection, bool withClose, bool alignLeft)
         {
+            m_alignLeft = alignLeft;
+
             m_listBox.reset(new BankItemsListBoxModel());
             m_label.reset(new juce::Label);
             m_label->setText(TRANS("No RPL loaded"), juce::dontSendNotification);
@@ -619,13 +627,13 @@ void YsfxRPLView::setLoadPresetCallback(std::function<void(ysfx_bank_shared, std
 
 void YsfxRPLView::Impl::createUI()
 {
-    m_left.createUI(false, false, false);
+    m_left.createUI(false, false, false, true);
     m_left.setLabelTooltip("Location of the currently loaded presets");
     m_self->addAndMakeVisible(m_left);
     m_left.setBankUpdatedCallback([this](void) { if (m_bankUpdateCallback) m_bankUpdateCallback(); });
     m_left.setLoadPresetCallback([this](ysfx_bank_shared bank, std::string name) { if (m_loadPresetCallback) this->m_loadPresetCallback(m_left.getBank(), name); });
 
-    m_right.createUI(true, true, true);
+    m_right.createUI(true, true, true, false);
     m_right.setLabelTooltip("Click to select preset file to import from");
     m_self->addAndMakeVisible(m_right);
     m_right.setLoadPresetCallback([this](ysfx_bank_shared bank, std::string name) { if (m_loadPresetCallback) this->m_loadPresetCallback(m_right.getBank(), name); });

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -73,7 +73,7 @@ class BankItemsListBoxModel final : public juce::ListBox, public juce::ListBoxMo
             if (rowNumber < 0) return;
 
             if (rowIsSelected)
-                g.fillAll (juce::Colours::lightblue);
+                g.fillAll(findColour(ListBox::backgroundColourId).contrasting(0.2f));
 
             g.setColour(juce::LookAndFeel::getDefaultLookAndFeel().findColour(juce::Label::textColourId));
             g.setFont((float) height * 0.7f);

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -252,7 +252,7 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
             if (m_file != juce::File{}) {
                 initialPath = m_file.getParentDirectory();
             }
-            m_fileChooser.reset(new juce::FileChooser(TRANS("Open bank..."), initialPath, juce::String(), m_useNativeFilePicker));
+            m_fileChooser.reset(new juce::FileChooser(TRANS("Open bank..."), initialPath, juce::String("*.rpl"), m_useNativeFilePicker));
             m_fileChooser->launchAsync(
                 juce::FileBrowserComponent::openMode|juce::FileBrowserComponent::canSelectFiles,
                 [this](const juce::FileChooser &chooser) {

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -164,6 +164,11 @@ class BankItemsListBoxModel final : public juce::ListBox, public juce::ListBoxMo
                 });
             }
         }
+
+        void backgroundClicked(const juce::MouseEvent &_) override
+        {
+            deselectAllRows();
+        }
 };
 
 class LoadedBank : public juce::Component, public juce::DragAndDropContainer {

--- a/plugin/components/rpl_view.cpp
+++ b/plugin/components/rpl_view.cpp
@@ -489,6 +489,19 @@ class LoadedBank : public juce::Component, public juce::DragAndDropContainer {
                 }
 
                 ysfx_bank_t* bank = load_bank(m_file.getFullPathName().toStdString().c_str());
+                if (!bank) {
+                    juce::AlertWindow::showAsync(
+                        juce::MessageBoxOptions()
+                            .withIconType(juce::MessageBoxIconType::WarningIcon)
+                            .withTitle("Error")
+                            .withMessage(m_file.getFileName().toStdString().c_str() + TRANS(" is not a valid RPL file."))
+                            .withButton("OK"),
+                        nullptr
+                    );
+                    m_file = juce::File{};
+
+                    return;
+                }
                 m_bank = make_ysfx_bank_shared(bank);
 
                 m_lastLoad = newTime;

--- a/plugin/components/rpl_view.h
+++ b/plugin/components/rpl_view.h
@@ -25,7 +25,7 @@ public:
     ~YsfxRPLView() override;
     void setEffect(ysfx_t *fx);
     void setBankUpdateCallback(std::function<void(void)> bankUpdateCallback);
-    void setLoadPresetCallback(std::function<void(std::string)> loadPresetCallback);
+    void setLoadPresetCallback(std::function<void(ysfx_bank_shared, std::string)> loadPresetCallback);
 
     void focusOnPresetViewer();
     void setUseNativeFilePicker(int useNativeFilePicker);

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -525,9 +525,8 @@ void YsfxEditor::Impl::updateInfo()
         }
     );
     m_rplView->setLoadPresetCallback(
-        [this](std::string preset) {
+        [this](ysfx_bank_shared bank, std::string preset) {
             YsfxInfo::Ptr ysfx_info = m_info;
-            ysfx_bank_shared bank = m_bank;
             if (!bank) return;
 
             auto index = ysfx_preset_exists(bank.get(), preset.c_str());

--- a/plugin/editor.cpp
+++ b/plugin/editor.cpp
@@ -630,6 +630,14 @@ void YsfxEditor::Impl::saveScaling()
                 m_pluginProperties->setValue(getKey("_divider"), m_divider->m_position);
             }
         }
+
+        if (m_presetWindow) {
+            auto position = m_presetWindow->getPosition();
+            m_pluginProperties->setValue("preset_manager_x", position.getX());
+            m_pluginProperties->setValue("preset_manager_y", position.getY());
+            m_pluginProperties->setValue("preset_manager_height", m_presetWindow->getHeight());
+            m_pluginProperties->setValue("preset_manager_width", m_presetWindow->getWidth());
+        }
     }
 }
 
@@ -940,6 +948,26 @@ void YsfxEditor::Impl::openPresetWindow()
         m_presetWindow.reset(new SubWindow(TRANS("Preset Manager"), m_self->findColour(juce::DocumentWindow::backgroundColourId), juce::DocumentWindow::allButtons, true, m_windowBehaviour));
         m_presetWindow->setResizable(true, false);
         m_presetWindow->setContentNonOwned(m_rplView.get(), true);
+    
+        juce::ComponentBoundsConstrainer constraint;
+        constraint.setMinimumOnscreenAmounts(50, 50, 50, 50);
+    
+        auto x = m_pluginProperties->getIntValue("preset_manager_x", -1);
+        auto y = m_pluginProperties->getIntValue("preset_manager_y", -1);
+        auto width = m_pluginProperties->getIntValue("preset_manager_width", -1);
+        auto height = m_pluginProperties->getIntValue("preset_manager_height", -1);
+
+        if (x >= 0 && y >= 0 && width > 0 && height > 0) {
+            auto savedBounds = juce::Rectangle<int>(x, y, width, height);
+
+            constraint.checkBounds(
+                savedBounds,
+                savedBounds,
+                juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea,
+                false, false, false, false
+            );
+            m_presetWindow->setBounds(savedBounds);
+        }
     }
 
     m_presetWindow->setVisible(true);

--- a/sources/ysfx_preset.cpp
+++ b/sources/ysfx_preset.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <cmath>
 #include <algorithm>
+#include <utility>
 
 #include <iomanip>
 #include <sstream>
@@ -413,6 +414,23 @@ ysfx_bank_t *ysfx_rename_preset_from_bank(ysfx_bank_t *bank_in, const char* pres
     }
 
     return bank.release();
+}
+
+// Swap two presets in-place. Does not clear the bank
+void ysfx_swap_preset_in_bank(ysfx_bank_t *bank, int32_t preset_idx_1, int32_t preset_idx_2)
+{
+    // Early out if we get invalid counts or in the no-change situation
+    if (
+        preset_idx_1 >= static_cast<int32_t>(bank->preset_count) || 
+        preset_idx_2 >= static_cast<int32_t>(bank->preset_count) || 
+        preset_idx_1 < 0 || 
+        preset_idx_2 < 0 ||
+        preset_idx_1 == preset_idx_2
+    ) {
+        return;
+    }
+
+    std::swap(bank->presets[preset_idx_1], bank->presets[preset_idx_2]);
 }
 
 std::string double_string(double value) {


### PR DESCRIPTION
- PresetManager: Fixed bug that would result in a crash when loading a non-RPL file in the preset manager.
- PresetManager: Added ability to manage presets for JSFX that don't come with a stock RPL file
- PresetManager: Added support for doubleclick loading of presets for presets loaded in the import column
- PresetManager: Ensure order is preserved when importing multiple presets.
- PresetManager: Added protection of the import column by adding an explicit checkbox to allow modification.
- PresetManager: Add option to move presets around.
- PresetManager: Add option to preview preset with enter key.
- PresetManager: Support closing the RPL file in the import pane.
- PresetManager: Store last position and size.
- PresetManager: Fix background color selection in listboxes.
- PresetManager: Allow deselecting all rows by clicking the background of the list box.
- ysfx: add API endpoint for swapping presets in-place (`ysfx_swap_preset_in_bank`)