### PR TITLE
ysfx: ensure `@gfx` initialization matches `jsfx`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 
 cmake_minimum_required(VERSION 3.15)
-project(ysfx VERSION "0.0.46" LANGUAGES C CXX ASM)
+project(ysfx VERSION "0.0.47" LANGUAGES C CXX ASM)
 
 # check if we are building from this project, or are imported by another
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/sources/ysfx_api_gfx.cpp
+++ b/sources/ysfx_api_gfx.cpp
@@ -327,9 +327,6 @@ void ysfx_gfx_enter(ysfx_t *fx, bool doinit)
 
     if (doinit) {
         if (fx->gfx.must_init.exchange(false, std::memory_order_acquire)) {
-            *fx->var.gfx_r = 1.0;
-            *fx->var.gfx_g = 1.0;
-            *fx->var.gfx_b = 1.0;
             *fx->var.gfx_a = 1.0;
             *fx->var.gfx_a2 = 1.0;
             *fx->var.gfx_dest = -1.0;
@@ -401,6 +398,9 @@ void ysfx_gfx_prepare(ysfx_t *fx)
     }
     *fx->var.gfx_w = gfx_w;
     *fx->var.gfx_h = gfx_h;
+    *fx->var.gfx_a = 1.0;
+    *fx->var.gfx_a2 = 1.0;
+    *fx->var.gfx_dest = -1.0;
 }
 
 #endif // !defined(YSFX_NO_GFX)


### PR DESCRIPTION
Ensures that `ysfx`'s graphics initialization matches the reference `jsfx` implementation. In JSFX, `gfx_r`, `gfx_g` and `gfx_b` are typically left uninitialized (zero), while `gfx_a`, `gfx_a2`, and `gfx_dest` are set to `1.0`, `1.0` and `-1.0`.